### PR TITLE
add settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Build
+npm run build          # Compile TypeScript + copy static files to dist/
+npm run watch          # Continuous compilation (tsc --watch)
+npm run clean          # Remove dist/
+
+# Lint & Format
+npm run lint           # ESLint + Prettier check
+npm run lint:fix       # ESLint auto-fix + Prettier format
+
+# Test
+npm test               # Run Jest tests
+npm run test:watch     # Jest watch mode
+npm run test:coverage  # Jest with coverage report
+```
+
+To load the extension in Chrome: go to `chrome://extensions`, enable Developer Mode, click "Load unpacked", select the `dist/` directory.
+
+## Architecture
+
+LiLimit is a Chrome Extension (Manifest V3) written in TypeScript. The extension has three main runtime contexts:
+
+**Background Service Worker** (`src/background/background.ts`)
+The core logic. Listens to Chrome tab events (`onUpdated`, `onActivated`, `onRemoved`) to track visits and enforce time limits. Uses `chrome.alarms` for daily midnight resets (survives service worker restarts). Communicates with the popup via `chrome.runtime.onMessage`.
+
+**Popup UI** (`src/popup/popup.ts` + `public/popup.html`)
+The user-facing interface with three tabs: "Set Limits", "Live Stats", and "All Limits". Sends messages to the background worker to read/write limits and stats. Handles settings, theme toggle (dark/light via localStorage), stats export, and search/filter.
+
+**Blocked Pages** (`public/pages/time-exceeded.html`, `public/pages/visits-exceeded.html`)
+Static pages the background redirects tabs to when a limit is exceeded. `src/pages/countdown.ts` is injected to show time until daily reset.
+
+**Shared** (`src/shared/`)
+`types.ts` — TypeScript interfaces for limits, stats, settings, and message types.
+`utils.ts` — `extractHostname()` and `limits_to_string()` helpers.
+
+### Data Flow
+
+```
+Chrome tab events → Background → chrome.storage.local
+Popup form submit → chrome.runtime.sendMessage → Background → Storage
+Limit exceeded → Background redirects tab to blocked page
+chrome.alarms ("dailyReset") → Background resets visitCounts, dailyTimeSpent, and active timers.
+```
+
+### Storage Schema
+
+All data is persisted to `chrome.storage.local`:
+
+- `timeLimits` — `{[hostname]: minutes}`
+- `visitLimits` — `{[hostname]: maxVisits}`
+- `visitCounts` — `{[hostname]: currentCount}`
+- `timerStartTimes` — `{[tabId]: {hostname, startTime}}`
+- `dailyTimeSpent` — `{[hostname]: milliseconds}` (accumulated time today; only used when `dailyTimeLimit` is on)
+- `settings` — `{dailyTimeLimit: boolean}`
+
+## Testing
+
+Tests live in `__tests__/`. The test environment is jsdom with Chrome extension APIs mocked. Coverage threshold is 50% (currently ~83%).
+
+The background tests address service worker initialization race conditions — the background uses a promise-based init pattern (`isInitialized` promise) to prevent concurrent storage access during startup.
+
+Test manually: ensure no CSP violations, verify background service worker functionality, and check popup/content scripts work correctly after manifest changes.
+
+## Build System
+
+TypeScript compiles `src/` → `dist/`. Static files (`manifest.json`, HTML, CSS, images) are copied from `public/` to `dist/` via `npm run copy:static`. There is no bundler (webpack/vite) — the extension uses native ES modules.
+
+CI runs lint → test → build sequentially via GitHub Actions (`.github/workflows/ci.yml`).
+
+## Git Workflow
+
+- Main branch: `main`
+- Create feature branches from main with descriptive names (e.g., `fix/csp-violations`, `feature/dark-mode`)
+- Do not include Claude as co-author in commits or add "Generated with Claude Code" messages
+
+## PR Review Process
+
+- Use `gh pr view <PR_NUMBER>` to see PR details
+- Check comments with `gh api repos/jonis100/LiLimit/pulls/<PR_NUMBER>/comments`
+- Address all feedback by fixing issues or responding to discuss, then push to the PR branch
+
+## Release Process
+
+1. Increment version in `manifest.json` following semantic versioning and commit
+2. Push all changes to the target branch
+3. Use `gh release create v<VERSION>` with release notes covering features, bug fixes, and other changes
+4. Target `main` for production releases
+
+## Code Style
+
+- Only add comments for complex logic, important warnings/edge cases, or JSDoc — not to restate what code does
+- Run `npm run lint:fix` before committing

--- a/__tests__/background.test.ts
+++ b/__tests__/background.test.ts
@@ -6,11 +6,16 @@
 import { jest } from '@jest/globals';
 import type { StatsResponse, LimitsResponse, StatItem, LimitItem } from '../src/shared/types.js';
 
+interface MockSettings {
+  countSwitchAsVisit: boolean;
+}
+
 interface MockStorageData {
   timeLimits?: Record<string, number>;
   visitLimits?: Record<string, number>;
   visitCounts?: Record<string, number>;
   timerStartTimes?: Record<string, { hostname: string; startTime: number }>;
+  settings?: MockSettings;
 }
 
 interface MockTab {
@@ -107,7 +112,7 @@ Object.defineProperty(global, 'chrome', {
 
 mockStorageGet.mockImplementation((...args: unknown[]) => {
   const callback = args[args.length - 1] as (data: MockStorageData) => void;
-  callback({ timeLimits: {}, visitLimits: {}, visitCounts: {}, timerStartTimes: {} });
+  callback({ timeLimits: {}, visitLimits: {}, visitCounts: {}, timerStartTimes: {}, settings: { countSwitchAsVisit: false } });
 });
 
 let messageListener: MessageListener;
@@ -125,7 +130,7 @@ describe('Background Script', () => {
     alarmListener = global.chrome.alarms.onAlarm.addListener.mock.calls[0][0];
 
     expect(global.chrome.storage.local.get).toHaveBeenCalledWith(
-      ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes'],
+      ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes', 'settings'],
       expect.any(Function)
     );
   });
@@ -138,7 +143,7 @@ describe('Background Script', () => {
     mockTabsQuery.mockResolvedValue([]);
     mockStorageGet.mockImplementation((...args: unknown[]) => {
       const callback = args[args.length - 1] as (data: MockStorageData) => void;
-      callback({ timeLimits: {}, visitLimits: {}, visitCounts: {}, timerStartTimes: {} });
+      callback({ timeLimits: {}, visitLimits: {}, visitCounts: {}, timerStartTimes: {}, settings: { countSwitchAsVisit: false } });
     });
   });
 
@@ -162,7 +167,7 @@ describe('Background Script', () => {
 
     test('should load persisted data from storage on startup', () => {
       expect(mockStorageGet).toHaveBeenCalledWith(
-        ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes'],
+        ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes', 'settings'],
         expect.any(Function)
       );
     });
@@ -441,7 +446,39 @@ describe('Background Script', () => {
   });
 
   describe('Tab Event - onActivated', () => {
-    test('should handle tab activation with valid URL', async () => {
+    test('should skip handleHostname when countSwitchAsVisit is false (default)', async () => {
+      // Ensure settings have countSwitchAsVisit = false (default)
+      messageListener(
+        { type: 'setSettings', settings: { countSwitchAsVisit: false } },
+        {},
+        jest.fn()
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      mockTabsGet.mockImplementation((...args: unknown[]) => {
+        const callback = args[1] as (tab: MockTab) => void;
+        callback({ url: 'https://example.com', pendingUrl: undefined });
+      });
+
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+      await onActivatedListener({ tabId: 1 });
+
+      const logMessages = consoleSpy.mock.calls.map((call) => call.join(' '));
+      expect(logMessages.some((msg) => msg.includes('tab switched hostname'))).toBe(false);
+
+      consoleSpy.mockRestore();
+    });
+
+    test('should call handleHostname when countSwitchAsVisit is true', async () => {
+      // Enable countSwitchAsVisit via message
+      messageListener(
+        { type: 'setSettings', settings: { countSwitchAsVisit: true } },
+        {},
+        jest.fn()
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
       mockTabsGet.mockImplementation((...args: unknown[]) => {
         const callback = args[1] as (tab: MockTab) => void;
         callback({ url: 'https://example.com', pendingUrl: undefined });
@@ -456,7 +493,15 @@ describe('Background Script', () => {
       consoleSpy.mockRestore();
     });
 
-    test('should handle new tabs with pendingUrl', async () => {
+    test('should handle new tabs with pendingUrl when countSwitchAsVisit is true', async () => {
+      // Enable countSwitchAsVisit via message
+      messageListener(
+        { type: 'setSettings', settings: { countSwitchAsVisit: true } },
+        {},
+        jest.fn()
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
       mockTabsGet.mockImplementation((...args: unknown[]) => {
         const callback = args[1] as (tab: MockTab) => void;
         callback({ url: 'about:blank', pendingUrl: 'https://pending.com' });
@@ -470,6 +515,74 @@ describe('Background Script', () => {
       expect(logMessages.some((msg) => msg.includes('new tab from onActivated'))).toBe(true);
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Message Handling - Settings', () => {
+    test('should return settings via getSettings', async () => {
+      // Reset to default first (previous tests may have changed it)
+      messageListener(
+        { type: 'setSettings', settings: { countSwitchAsVisit: false } },
+        {},
+        jest.fn()
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const sendResponse = jest.fn();
+      messageListener({ type: 'getSettings' }, {}, sendResponse);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const response = sendResponse.mock.calls[0][0] as { settings: MockSettings };
+      expect(response.settings).toBeDefined();
+      expect(response.settings.countSwitchAsVisit).toBe(false);
+    });
+
+    test('should update settings via setSettings', async () => {
+      const sendResponse = jest.fn();
+
+      messageListener(
+        { type: 'setSettings', settings: { countSwitchAsVisit: true } },
+        {},
+        sendResponse
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(sendResponse).toHaveBeenCalledWith({ success: true });
+      expect(mockStorageSet).toHaveBeenCalledWith({ settings: { countSwitchAsVisit: true } });
+    });
+
+    test('should return updated settings after setSettings', async () => {
+      const sendResponse1 = jest.fn();
+      messageListener(
+        { type: 'setSettings', settings: { countSwitchAsVisit: true } },
+        {},
+        sendResponse1
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const sendResponse2 = jest.fn();
+      messageListener({ type: 'getSettings' }, {}, sendResponse2);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const response = sendResponse2.mock.calls[0][0] as { settings: MockSettings };
+      expect(response.settings.countSwitchAsVisit).toBe(true);
+    });
+
+    test('should persist settings to chrome.storage.local', async () => {
+      const sendResponse = jest.fn();
+
+      messageListener(
+        { type: 'setSettings', settings: { countSwitchAsVisit: false } },
+        {},
+        sendResponse
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockStorageSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          settings: expect.objectContaining({ countSwitchAsVisit: false }),
+        })
+      );
     });
   });
 

--- a/__tests__/background.test.ts
+++ b/__tests__/background.test.ts
@@ -7,7 +7,7 @@ import { jest } from '@jest/globals';
 import type { StatsResponse, LimitsResponse, StatItem, LimitItem } from '../src/shared/types.js';
 
 interface MockSettings {
-  countSwitchAsVisit: boolean;
+  dailyTimeLimit: boolean;
 }
 
 interface MockStorageData {
@@ -15,6 +15,7 @@ interface MockStorageData {
   visitLimits?: Record<string, number>;
   visitCounts?: Record<string, number>;
   timerStartTimes?: Record<string, { hostname: string; startTime: number }>;
+  dailyTimeSpent?: Record<string, number>;
   settings?: MockSettings;
 }
 
@@ -112,7 +113,13 @@ Object.defineProperty(global, 'chrome', {
 
 mockStorageGet.mockImplementation((...args: unknown[]) => {
   const callback = args[args.length - 1] as (data: MockStorageData) => void;
-  callback({ timeLimits: {}, visitLimits: {}, visitCounts: {}, timerStartTimes: {}, settings: { countSwitchAsVisit: false } });
+  callback({
+    timeLimits: {},
+    visitLimits: {},
+    visitCounts: {},
+    timerStartTimes: {},
+    settings: { dailyTimeLimit: false },
+  });
 });
 
 let messageListener: MessageListener;
@@ -130,7 +137,7 @@ describe('Background Script', () => {
     alarmListener = global.chrome.alarms.onAlarm.addListener.mock.calls[0][0];
 
     expect(global.chrome.storage.local.get).toHaveBeenCalledWith(
-      ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes', 'settings'],
+      ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes', 'dailyTimeSpent', 'settings'],
       expect.any(Function)
     );
   });
@@ -143,7 +150,13 @@ describe('Background Script', () => {
     mockTabsQuery.mockResolvedValue([]);
     mockStorageGet.mockImplementation((...args: unknown[]) => {
       const callback = args[args.length - 1] as (data: MockStorageData) => void;
-      callback({ timeLimits: {}, visitLimits: {}, visitCounts: {}, timerStartTimes: {}, settings: { countSwitchAsVisit: false } });
+      callback({
+        timeLimits: {},
+        visitLimits: {},
+        visitCounts: {},
+        timerStartTimes: {},
+        settings: { dailyTimeLimit: false },
+      });
     });
   });
 
@@ -167,7 +180,14 @@ describe('Background Script', () => {
 
     test('should load persisted data from storage on startup', () => {
       expect(mockStorageGet).toHaveBeenCalledWith(
-        ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes', 'settings'],
+        [
+          'timeLimits',
+          'visitLimits',
+          'visitCounts',
+          'timerStartTimes',
+          'dailyTimeSpent',
+          'settings',
+        ],
         expect.any(Function)
       );
     });
@@ -446,62 +466,7 @@ describe('Background Script', () => {
   });
 
   describe('Tab Event - onActivated', () => {
-    test('should skip handleHostname when countSwitchAsVisit is false (default)', async () => {
-      // Ensure settings have countSwitchAsVisit = false (default)
-      messageListener(
-        { type: 'setSettings', settings: { countSwitchAsVisit: false } },
-        {},
-        jest.fn()
-      );
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      mockTabsGet.mockImplementation((...args: unknown[]) => {
-        const callback = args[1] as (tab: MockTab) => void;
-        callback({ url: 'https://example.com', pendingUrl: undefined });
-      });
-
-      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-
-      await onActivatedListener({ tabId: 1 });
-
-      const logMessages = consoleSpy.mock.calls.map((call) => call.join(' '));
-      expect(logMessages.some((msg) => msg.includes('tab switched hostname'))).toBe(false);
-
-      consoleSpy.mockRestore();
-    });
-
-    test('should call handleHostname when countSwitchAsVisit is true', async () => {
-      // Enable countSwitchAsVisit via message
-      messageListener(
-        { type: 'setSettings', settings: { countSwitchAsVisit: true } },
-        {},
-        jest.fn()
-      );
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      mockTabsGet.mockImplementation((...args: unknown[]) => {
-        const callback = args[1] as (tab: MockTab) => void;
-        callback({ url: 'https://example.com', pendingUrl: undefined });
-      });
-
-      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-
-      await onActivatedListener({ tabId: 1 });
-
-      expect(mockTabsGet).toHaveBeenCalledWith(1, expect.any(Function));
-
-      consoleSpy.mockRestore();
-    });
-
-    test('should handle new tabs with pendingUrl when countSwitchAsVisit is true', async () => {
-      // Enable countSwitchAsVisit via message
-      messageListener(
-        { type: 'setSettings', settings: { countSwitchAsVisit: true } },
-        {},
-        jest.fn()
-      );
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
+    test('should not call handleHostname for new tabs with pendingUrl', async () => {
       mockTabsGet.mockImplementation((...args: unknown[]) => {
         const callback = args[1] as (tab: MockTab) => void;
         callback({ url: 'about:blank', pendingUrl: 'https://pending.com' });
@@ -513,19 +478,67 @@ describe('Background Script', () => {
 
       const logMessages = consoleSpy.mock.calls.map((call) => call.join(' '));
       expect(logMessages.some((msg) => msg.includes('new tab from onActivated'))).toBe(true);
+      expect(logMessages.some((msg) => msg.includes('tab switched hostname'))).toBe(false);
 
       consoleSpy.mockRestore();
+    });
+
+    test('should call handleHostname when tab has a valid URL', async () => {
+      mockTabsGet.mockImplementation((...args: unknown[]) => {
+        const callback = args[1] as (tab: MockTab) => void;
+        callback({ id: 1, url: 'https://example.com', pendingUrl: undefined });
+      });
+
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+      await onActivatedListener({ tabId: 1 });
+
+      expect(mockTabsGet).toHaveBeenCalledWith(1, expect.any(Function));
+      const logMessages = consoleSpy.mock.calls.map((call) => call.join(' '));
+      expect(logMessages.some((msg) => msg.includes('tab switched hostname'))).toBe(true);
+
+      consoleSpy.mockRestore();
+    });
+
+    test('should pause previous tab timer in daily mode when switching tabs', async () => {
+      const hostname = `dailypausetest${Date.now()}.com`;
+
+      messageListener({ type: 'setSettings', settings: { dailyTimeLimit: true } }, {}, jest.fn());
+      messageListener({ type: 'setTimeLimit', hostname, timeLimit: 5 }, {}, jest.fn());
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      mockTabsGet.mockImplementation((...args: unknown[]) => {
+        const tabId = args[0] as number;
+        const callback = args[1] as (tab: MockTab) => void;
+        callback(
+          tabId === 200
+            ? { id: 200, url: `https://${hostname}`, pendingUrl: undefined }
+            : { id: tabId, url: 'https://other.com', pendingUrl: undefined }
+        );
+      });
+
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+      await onActivatedListener({ tabId: 200 });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await onActivatedListener({ tabId: 201 });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const logMessages = consoleSpy.mock.calls.map((call) => call.join(' '));
+      expect(
+        logMessages.some((msg) => msg.includes(`Paused daily timer for ${hostname}`))
+      ).toBe(true);
+
+      consoleSpy.mockRestore();
+
+      messageListener({ type: 'setSettings', settings: { dailyTimeLimit: false } }, {}, jest.fn());
+      await new Promise((resolve) => setTimeout(resolve, 50));
     });
   });
 
   describe('Message Handling - Settings', () => {
     test('should return settings via getSettings', async () => {
-      // Reset to default first (previous tests may have changed it)
-      messageListener(
-        { type: 'setSettings', settings: { countSwitchAsVisit: false } },
-        {},
-        jest.fn()
-      );
+      messageListener({ type: 'setSettings', settings: { dailyTimeLimit: false } }, {}, jest.fn());
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       const sendResponse = jest.fn();
@@ -534,54 +547,47 @@ describe('Background Script', () => {
 
       const response = sendResponse.mock.calls[0][0] as { settings: MockSettings };
       expect(response.settings).toBeDefined();
-      expect(response.settings.countSwitchAsVisit).toBe(false);
+      expect(response.settings.dailyTimeLimit).toBe(false);
     });
 
     test('should update settings via setSettings', async () => {
       const sendResponse = jest.fn();
 
-      messageListener(
-        { type: 'setSettings', settings: { countSwitchAsVisit: true } },
-        {},
-        sendResponse
-      );
+      messageListener({ type: 'setSettings', settings: { dailyTimeLimit: true } }, {}, sendResponse);
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(sendResponse).toHaveBeenCalledWith({ success: true });
-      expect(mockStorageSet).toHaveBeenCalledWith({ settings: { countSwitchAsVisit: true } });
-    });
-
-    test('should return updated settings after setSettings', async () => {
-      const sendResponse1 = jest.fn();
-      messageListener(
-        { type: 'setSettings', settings: { countSwitchAsVisit: true } },
-        {},
-        sendResponse1
+      expect(mockStorageSet).toHaveBeenCalledWith(
+        expect.objectContaining({ settings: { dailyTimeLimit: true } }),
+        expect.any(Function)
       );
-      await new Promise((resolve) => setTimeout(resolve, 50));
 
-      const sendResponse2 = jest.fn();
-      messageListener({ type: 'getSettings' }, {}, sendResponse2);
+      messageListener({ type: 'setSettings', settings: { dailyTimeLimit: false } }, {}, jest.fn());
       await new Promise((resolve) => setTimeout(resolve, 50));
-
-      const response = sendResponse2.mock.calls[0][0] as { settings: MockSettings };
-      expect(response.settings.countSwitchAsVisit).toBe(true);
     });
 
-    test('should persist settings to chrome.storage.local', async () => {
+    test('should return updated dailyTimeLimit after setSettings', async () => {
+      messageListener({ type: 'setSettings', settings: { dailyTimeLimit: true } }, {}, jest.fn());
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
       const sendResponse = jest.fn();
+      messageListener({ type: 'getSettings' }, {}, sendResponse);
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
-      messageListener(
-        { type: 'setSettings', settings: { countSwitchAsVisit: false } },
-        {},
-        sendResponse
-      );
+      const response = sendResponse.mock.calls[0][0] as { settings: MockSettings };
+      expect(response.settings.dailyTimeLimit).toBe(true);
+
+      messageListener({ type: 'setSettings', settings: { dailyTimeLimit: false } }, {}, jest.fn());
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    test('should persist dailyTimeLimit to chrome.storage.local', async () => {
+      messageListener({ type: 'setSettings', settings: { dailyTimeLimit: false } }, {}, jest.fn());
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(mockStorageSet).toHaveBeenCalledWith(
-        expect.objectContaining({
-          settings: expect.objectContaining({ countSwitchAsVisit: false }),
-        })
+        expect.objectContaining({ settings: { dailyTimeLimit: false } }),
+        expect.any(Function)
       );
     });
   });
@@ -713,6 +719,7 @@ describe('Background Script', () => {
           visitLimits: expect.any(Object),
           visitCounts: expect.any(Object),
           timerStartTimes: expect.any(Object),
+          dailyTimeSpent: expect.any(Object),
         }),
         expect.any(Function)
       );

--- a/__tests__/background.test.ts
+++ b/__tests__/background.test.ts
@@ -525,9 +525,9 @@ describe('Background Script', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       const logMessages = consoleSpy.mock.calls.map((call) => call.join(' '));
-      expect(
-        logMessages.some((msg) => msg.includes(`Paused daily timer for ${hostname}`))
-      ).toBe(true);
+      expect(logMessages.some((msg) => msg.includes(`Paused daily timer for ${hostname}`))).toBe(
+        true
+      );
 
       consoleSpy.mockRestore();
 
@@ -553,7 +553,11 @@ describe('Background Script', () => {
     test('should update settings via setSettings', async () => {
       const sendResponse = jest.fn();
 
-      messageListener({ type: 'setSettings', settings: { dailyTimeLimit: true } }, {}, sendResponse);
+      messageListener(
+        { type: 'setSettings', settings: { dailyTimeLimit: true } },
+        {},
+        sendResponse
+      );
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(sendResponse).toHaveBeenCalledWith({ success: true });

--- a/public/popup.css
+++ b/public/popup.css
@@ -83,7 +83,6 @@ body {
   filter: brightness(0) saturate(100%) invert(88%) sepia(14%) saturate(1372%) hue-rotate(95deg)
     brightness(95%) contrast(90%);
   transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  cursor: pointer;
 }
 .logo:hover {
   transform: rotate(5deg) scale(1.05);
@@ -941,10 +940,42 @@ input[type='number']:focus::-webkit-outer-spin-button {
   background: rgba(0, 0, 0, 0.12);
 }
 
-.setting-row .theme-toggle {
-  margin-left: 0;
-  flex-shrink: 0;
+.setting-row-clickable {
+  cursor: pointer;
 }
-.setting-row .theme-toggle:hover {
-  transform: none;
+
+.theme-icons {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  color: var(--muted);
+}
+
+.theme-icons .sun-icon,
+.theme-icons .moon-icon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.theme-icons .sun-icon {
+  opacity: 0;
+  transform: rotate(180deg) scale(0.5);
+}
+
+.theme-icons .moon-icon {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+}
+
+[data-theme='light'] .theme-icons .sun-icon {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+}
+
+[data-theme='light'] .theme-icons .moon-icon {
+  opacity: 0;
+  transform: rotate(-180deg) scale(0.5);
 }

--- a/public/popup.css
+++ b/public/popup.css
@@ -97,7 +97,7 @@ body {
 
 .theme-toggle {
   position: relative;
-  background: var(--card-bg);
+  background: var(--hover-bg);
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 8px;
@@ -107,16 +107,31 @@ body {
   justify-content: center;
   transition:
     background 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
     transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   margin-left: auto;
   color: var(--text);
 }
 .theme-toggle:hover {
-  background: var(--hover-bg);
+  background: rgba(255, 255, 255, 0.08);
   transform: translateY(-1px);
+}
+[data-theme='light'] .theme-toggle:hover {
+  background: rgba(0, 0, 0, 0.08);
 }
 .theme-toggle:active {
   transform: scale(0.95);
+}
+
+#settingsBtn.active {
+  background: rgba(110, 231, 183, 0.15);
+  color: var(--accent);
+  border-color: rgba(110, 231, 183, 0.3);
+  box-shadow: 0 2px 8px rgba(110, 231, 183, 0.1);
+}
+[data-theme='light'] #settingsBtn.active {
+  background: rgba(16, 185, 129, 0.1);
+  border-color: rgba(16, 185, 129, 0.25);
 }
 .theme-toggle .sun-icon,
 .theme-toggle .moon-icon {
@@ -818,4 +833,118 @@ input[type='number']:focus::-webkit-outer-spin-button {
 
 .form-header > .label {
   margin-bottom: 0;
+}
+
+.settings-container {
+  background: var(--card-bg);
+  border-radius: var(--radius);
+  padding: 12px;
+  box-shadow: 0 6px 18px rgba(2, 6, 23, 0.6);
+  border: 1px solid var(--border);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+[data-theme='light'] .settings-container {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.settings-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 12px 0;
+  color: var(--text);
+  padding-bottom: 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.setting-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 10px;
+  border-radius: 8px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  transition: all 0.2s ease;
+}
+
+.setting-row:hover {
+  background: var(--hover-bg);
+}
+
+.setting-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.setting-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.setting-desc {
+  font-size: 11px;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+/* Toggle Switch */
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 22px;
+  flex-shrink: 0;
+}
+
+.toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 22px;
+  transition: background 0.3s ease;
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  left: 3px;
+  bottom: 3px;
+  background: var(--muted);
+  border-radius: 50%;
+  transition: all 0.3s ease;
+}
+
+.toggle input:checked + .toggle-slider {
+  background: rgba(110, 231, 183, 0.3);
+}
+
+.toggle input:checked + .toggle-slider::before {
+  transform: translateX(18px);
+  background: var(--accent);
+}
+
+[data-theme='light'] .toggle-slider {
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.setting-row .theme-toggle {
+  margin-left: 0;
+  flex-shrink: 0;
+}
+.setting-row .theme-toggle:hover {
+  transform: none;
 }

--- a/public/popup.html
+++ b/public/popup.html
@@ -196,12 +196,18 @@
       <div id="settings" class="tab-content">
         <div class="settings-container">
           <h3 class="settings-title">Settings</h3>
-          <div class="setting-row">
+          <div
+            id="themeToggle"
+            class="setting-row setting-row-clickable"
+            role="button"
+            tabindex="0"
+            aria-label="Toggle theme"
+          >
             <div class="setting-info">
               <span class="setting-label">Dark mode</span>
               <span class="setting-desc">Toggle between dark and light theme</span>
             </div>
-            <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
+            <div class="theme-icons">
               <svg
                 class="sun-icon"
                 width="18"
@@ -232,15 +238,24 @@
               >
                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
               </svg>
-            </button>
-          </div>
-          <div class="setting-row">
-            <div class="setting-info">
-              <span class="setting-label">Count tab switch as new visit</span>
-              <span class="setting-desc">When off, only navigating to a URL counts as a visit</span>
             </div>
-            <label class="toggle">
-              <input type="checkbox" id="countSwitchAsVisit" />
+          </div>
+          <div
+            id="dailyTimeLimitRow"
+            class="setting-row setting-row-clickable"
+            role="button"
+            tabindex="0"
+            aria-label="Toggle daily time limit"
+          >
+            <div class="setting-info">
+              <span class="setting-label">Daily time limit</span>
+              <span class="setting-desc"
+                >When on, time accumulates across all visits today instead of resetting each
+                visit</span
+              >
+            </div>
+            <label class="toggle" aria-hidden="true">
+              <input type="checkbox" id="dailyTimeLimit" tabindex="-1" />
               <span class="toggle-slider"></span>
             </label>
           </div>

--- a/public/popup.html
+++ b/public/popup.html
@@ -11,9 +11,8 @@
       <header class="header">
         <img src="images/lily.png" alt="LiLimit logo" class="logo" />
         <h1 class="title">LiLimit</h1>
-        <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
+        <button id="settingsBtn" class="theme-toggle" aria-label="Settings">
           <svg
-            class="sun-icon"
             width="18"
             height="18"
             viewBox="0 0 24 24"
@@ -21,26 +20,10 @@
             stroke="currentColor"
             stroke-width="2"
           >
-            <circle cx="12" cy="12" r="5" />
-            <line x1="12" y1="1" x2="12" y2="3" />
-            <line x1="12" y1="21" x2="12" y2="23" />
-            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-            <line x1="1" y1="12" x2="3" y2="12" />
-            <line x1="21" y1="12" x2="23" y2="12" />
-            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-          </svg>
-          <svg
-            class="moon-icon"
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+            <circle cx="12" cy="12" r="3" />
+            <path
+              d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1.08-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1.08 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+            />
           </svg>
         </button>
       </header>
@@ -205,6 +188,61 @@
               </svg>
               <p>No limits set yet</p>
             </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Settings Tab -->
+      <div id="settings" class="tab-content">
+        <div class="settings-container">
+          <h3 class="settings-title">Settings</h3>
+          <div class="setting-row">
+            <div class="setting-info">
+              <span class="setting-label">Dark mode</span>
+              <span class="setting-desc">Toggle between dark and light theme</span>
+            </div>
+            <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
+              <svg
+                class="sun-icon"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <circle cx="12" cy="12" r="5" />
+                <line x1="12" y1="1" x2="12" y2="3" />
+                <line x1="12" y1="21" x2="12" y2="23" />
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+                <line x1="1" y1="12" x2="3" y2="12" />
+                <line x1="21" y1="12" x2="23" y2="12" />
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+              </svg>
+              <svg
+                class="moon-icon"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+              </svg>
+            </button>
+          </div>
+          <div class="setting-row">
+            <div class="setting-info">
+              <span class="setting-label">Count tab switch as new visit</span>
+              <span class="setting-desc">When off, only navigating to a URL counts as a visit</span>
+            </div>
+            <label class="toggle">
+              <input type="checkbox" id="countSwitchAsVisit" />
+              <span class="toggle-slider"></span>
+            </label>
           </div>
         </div>
       </div>

--- a/settings-tab-plan.md
+++ b/settings-tab-plan.md
@@ -2,229 +2,168 @@
 
 ## Motivation
 
-Both `chrome.tabs.onUpdated` (URL navigation) and `chrome.tabs.onActivated` (tab switching) call `handleHostname()`, which increments `visitCounts[hostname]` whenever `lastHandle[tabID] != hostname`.
+Currently, the time limit per website resets on every visit — each time you navigate to a site, you get the full X minutes fresh. This means you can visit a site 20 times and never accumulate more than X minutes of time pressure.
 
-This means switching to an already-open tab can count as a new visit. Additionally, because `lastHandle` is in-memory only, any MV3 service worker restart resets it — so the very next tab activation after a restart counts as a fresh visit even without any navigation.
-
-Users should be able to choose what counts as a visit: new URL navigations only, or tab switches too.
+The settings tab lets users switch to **daily time limit mode**, where time spent on a website accumulates across all visits throughout the day. Once you've used up your X-minute budget for the day, you're blocked — regardless of how many separate visits it took.
 
 ---
 
 ## New Setting
 
-| Key | Type | Default | Description |
-|---|---|---|---|
-| `countSwitchAsVisit` | `boolean` | **`true`** | When `false`, switching to an existing tab does **not** count as a new visit and does **not** restart the timer. Only navigating to a new URL (via `onUpdated`) triggers `handleHostname()`. |
+| Key              | Type      | Default     | Description                                                                                                                            |
+| ---------------- | --------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `dailyTimeLimit` | `boolean` | **`false`** | When `true`, time spent on a site accumulates across all visits today. When `false` (default), each visit gets a fresh X-minute timer. |
 
 **Scope:** Global (applies to all tracked hostnames).
 
 ---
 
-## Behavior Alignment
+## Behavior
 
-Both visit counting and timer start share the **same** guard condition in `handleHostname()` ([background.ts:196-218](src/background/background.ts#L196-L218)):
+### Per-visit mode (`dailyTimeLimit = false`, default)
 
-```ts
-// visit counting
-if (visitLimits[hostname] && lastHandle[tabID] != hostname) {
-  visitCounts[hostname]++;
-}
-// timer start
-if (timeLimits[hostname] && lastHandle[tabID] !== hostname) {
-  setTimerForTab(tabID, hostname, timeLimit);
-}
-```
+Existing behavior: each new navigation to a tracked hostname starts a fresh timer. Switching to the tab or re-opening it resets nothing — the same visit's timer keeps running.
 
-Because both use the same `lastHandle` check, the setting controls **both** in one shot:
-- `countSwitchAsVisit = false` → `onActivated` **skips** `handleHostname()` entirely → no visit increment, no timer restart on tab switch.
-- `countSwitchAsVisit = true` → `onActivated` calls `handleHostname()` as it does today → visit count and timer both fire on switch.
+### Daily mode (`dailyTimeLimit = true`)
 
-Timers are already persisted via `timerStartTimes` in storage and restored on service-worker wake by `restoreTimers()` ([background.ts:169-191](src/background/background.ts#L169-L191)), so skipping `handleHostname()` on activation doesn't break ongoing time tracking.
+- A `dailyTimeSpent[hostname]` counter (in ms) accumulates time across all visits.
+- When you navigate to or activate a tracked tab: check remaining = `timeLimit * 60000 - dailyTimeSpent[hostname]`. If ≤ 0, redirect immediately. Otherwise start a timer for the remaining time.
+- When you switch away from a tab (another tab activated): add elapsed ms to `dailyTimeSpent[hostname]` and pause the timer.
+- When you navigate to a different URL in the same tab: add elapsed ms before clearing the timer.
+- When the timer fires (time runs out mid-visit): mark `dailyTimeSpent[hostname] = timeLimit * 60000` so any new visit is blocked immediately.
+- At midnight daily reset: `dailyTimeSpent` is cleared along with visit counts and timers.
+- On service worker restart (`restoreTimers`): elapsed time since the interrupted session start is added to `dailyTimeSpent` before resuming.
 
 ---
 
-## Implementation Steps
+## Implementation
 
-### 1. Types — `src/background/background.ts` (local interfaces)
-
-`StorageData` and `MessageRequest` are defined **locally** in [background.ts:28-40](src/background/background.ts#L28-L40), not in `types.ts`.
-
-Add a `Settings` interface and update `StorageData`:
+### 1. Types — `src/shared/types.ts`
 
 ```ts
-interface Settings {
-  countSwitchAsVisit: boolean;
+export interface Settings {
+  dailyTimeLimit: boolean;
 }
-
-const DEFAULT_SETTINGS: Settings = { countSwitchAsVisit: true };
 ```
-
-Add `settings?: Settings` to `StorageData`.
-
-Also export `Settings` from `src/shared/types.ts` so the popup can use it for the message response type.
 
 ### 2. Background state — `src/background/background.ts`
 
-Add a module-level variable after the existing state declarations (line ~60):
-
 ```ts
-let settings: Settings = { ...DEFAULT_SETTINGS };
+interface Settings {
+  dailyTimeLimit: boolean;
+}
+const DEFAULT_SETTINGS: Settings = { dailyTimeLimit: false };
 ```
 
-#### 2a. Load settings on startup
-
-Update `initializeFromStorage()` ([background.ts:65-106](src/background/background.ts#L65-L106)) to include `'settings'` in the keys array:
+New module-level state:
 
 ```ts
-chrome.storage.local.get(
-  ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes', 'settings'],
-  ...
-)
+const dailyTimeSpent: { [hostname: string]: number } = {};
+let currentActiveTabId: number | null = null;
 ```
 
-And in the result handler:
+Add `dailyTimeSpent` to `StorageData`, `initializeFromStorage` (keys + result handler), `updateStorage`, and the daily reset alarm handler.
+
+### 3. `handleHostname()` — time limit branch
 
 ```ts
-if (result && result.settings) Object.assign(settings, result.settings);
-```
-
-> **Do NOT add settings to `updateStorage()`** — settings rarely change (user action only), while `updateStorage()` runs on every timer tick. Keep them separate.
-
-#### 2b. Guard `onActivated`
-
-In `chrome.tabs.onActivated` ([background.ts:309-325](src/background/background.ts#L309-L325)):
-
-```ts
-chrome.tabs.onActivated.addListener(async (activeInfo) => {
-  try {
-    await initializeFromStorage();
-    if (!settings.countSwitchAsVisit) return;   // ← new guard
-
-    chrome.tabs.get(activeInfo.tabId, (tab) => {
-      if (typeof tab.pendingUrl == 'undefined' && tab.url && tab.id) {
-        const hostname = extractHostname(tab.url);
-        handleHostname(hostname, tab.id);
+if (timeLimits[hostname]) {
+  if (settings.dailyTimeLimit) {
+    if (!timers[tabID]) {
+      // no active timer = tab was inactive or first visit
+      const remainingMs = timeLimits[hostname] * 60000 - (dailyTimeSpent[hostname] || 0);
+      if (remainingMs <= 0) {
+        redirectTabToTimeExceeded(tabID);
+        return;
       }
-    });
-  } catch (error) {
-    console.log("Can't handle in onActivated:", error);
+      setTimerForTab(tabID, hostname, remainingMs / 60000);
+    }
+  } else if (lastHandle[tabID] !== hostname) {
+    setTimerForTab(tabID, hostname, timeLimits[hostname]);
   }
-});
+}
 ```
 
-#### 2c. Message handlers
-
-Add to the `switch` in `onMessage` ([background.ts:338-430](src/background/background.ts#L338-L430)):
+### 4. `onActivated` — pause previous tab in daily mode
 
 ```ts
-case 'getSettings': {
-  sendResponse({ settings });
-  break;
-}
-
-case 'setSettings': {
-  if (request.settings) {
-    Object.assign(settings, request.settings);
-    chrome.storage.local.set({ settings });
+if (
+  settings.dailyTimeLimit &&
+  currentActiveTabId !== null &&
+  currentActiveTabId !== activeInfo.tabId
+) {
+  if (timerStartTimes[prevTabId]) {
+    const elapsed = Date.now() - timerStartTimes[prevTabId].startTime;
+    dailyTimeSpent[hostname] = (dailyTimeSpent[hostname] || 0) + elapsed;
+    clearTimeout(timers[prevTabId]);
+    delete timers[prevTabId];
+    delete timerStartTimes[prevTabId];
+    updateStorage();
   }
-  sendResponse({ success: true });
-  break;
 }
+currentActiveTabId = activeInfo.tabId;
 ```
 
-Update `MessageRequest` to accept an optional `settings` field:
+### 5. `onUpdated` — accumulate before clearing timer
+
+When navigating away from a hostname in daily mode, add elapsed time before the existing timer-clear logic.
+
+### 6. `setTimerForTab` — mark hostname fully spent on expiry
 
 ```ts
-interface MessageRequest {
-  type: string;
-  hostname?: string;
-  visitLimit?: number;
-  timeLimit?: number;
-  settings?: Settings;   // ← add
+const timer = setTimeout(() => {
+  if (settings.dailyTimeLimit) dailyTimeSpent[hostname] = timeLimits[hostname] * 60000;
+  // ... existing cleanup + redirect
+}, remainingMinutes * 60000);
+```
+
+### 7. `restoreTimers` — daily mode path
+
+Accumulate elapsed time from the interrupted segment, then resume or block:
+
+```ts
+if (settings.dailyTimeLimit) {
+  dailyTimeSpent[hostname] += Date.now() - startTime;
+  delete timerStartTimes[tabID];
+  const remainingMs = timeLimit * 60000 - dailyTimeSpent[hostname];
+  remainingMs > 0
+    ? setTimerForTab(tabID, hostname, remainingMs / 60000)
+    : redirectTabToTimeExceeded(tabID);
 }
 ```
 
-### 3. Popup UI — `public/popup.html`
+### 8. Popup UI — `public/popup.html`
 
-Add a 4th tab button to the `<nav>` (after "All Limits", [popup.html:48-52](public/popup.html#L48-L52)):
-
-```html
-<button class="tab-btn" data-tab="settings">
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
-       stroke="currentColor" stroke-width="2">
-    <circle cx="12" cy="12" r="3"/>
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l..."/>  <!-- gear icon -->
-  </svg>
-</button>
-```
-
-Add the settings panel (after the "all-limits" div, [popup.html:210](public/popup.html#L210)):
+Settings panel row:
 
 ```html
-<!-- Settings Tab -->
-<div id="settings" class="tab-content">
-  <div class="settings-container">
-    <h3 class="settings-title">Settings</h3>
-    <div class="setting-row">
-      <div class="setting-info">
-        <span class="setting-label">Count tab switch as new visit</span>
-        <span class="setting-desc">When off, only navigating to a URL counts as a visit</span>
-      </div>
-      <label class="toggle">
-        <input type="checkbox" id="countSwitchAsVisit" />
-        <span class="toggle-slider"></span>
-      </label>
-    </div>
+<div class="setting-row">
+  <div class="setting-info">
+    <span class="setting-label">Daily time limit</span>
+    <span class="setting-desc"
+      >When on, time accumulates across all visits today instead of resetting each visit</span
+    >
   </div>
+  <label class="toggle">
+    <input type="checkbox" id="dailyTimeLimit" />
+    <span class="toggle-slider"></span>
+  </label>
 </div>
 ```
 
-Existing tab system in `initTabs()` ([popup.ts:10-34](src/popup/popup.ts#L10-L34)) already handles any `data-tab` / `.tab-content` pairs — no JS change needed for tab switching itself.
+### 9. Popup logic — `src/popup/popup.ts`
 
-### 4. Popup logic — `src/popup/popup.ts`
+`loadSettings()` reads `response.settings.dailyTimeLimit` into `#dailyTimeLimit` checkbox.
+Change listener sends `{ type: 'setSettings', settings: { dailyTimeLimit: toggle.checked } }`.
 
-Add a `loadSettings()` function and a change listener:
+### 10. Tests — `__tests__/`
 
-```ts
-async function loadSettings(): Promise<void> {
-  const response = await chrome.runtime.sendMessage({ type: 'getSettings' });
-  const toggle = document.getElementById('countSwitchAsVisit') as HTMLInputElement;
-  if (toggle && response?.settings) {
-    toggle.checked = response.settings.countSwitchAsVisit;
-  }
-}
-```
-
-Wire it up in `initTabs()` — when `targetTab === 'settings'`, call `loadSettings()`.
-
-Add toggle change handler in `DOMContentLoaded`:
-
-```ts
-const switchToggle = document.getElementById('countSwitchAsVisit') as HTMLInputElement;
-if (switchToggle) {
-  switchToggle.addEventListener('change', () => {
-    chrome.runtime.sendMessage({
-      type: 'setSettings',
-      settings: { countSwitchAsVisit: switchToggle.checked },
-    });
-  });
-}
-```
-
-### 5. Styles — `public/popup.css`
-
-- `.settings-container`, `.setting-row` (flex row with space-between)
-- `.setting-label`, `.setting-desc` (text styles)
-- `.toggle` / `.toggle-slider` (CSS-only toggle switch)
-- Use existing theme variables (`--bg`, `--text`, `--border`, etc.) — no new colors needed.
-
-### 6. Tests — `__tests__/`
-
-- `onActivated` skips `handleHostname()` when `countSwitchAsVisit = false`.
-- `onActivated` calls `handleHostname()` when `countSwitchAsVisit = true` (default).
-- Settings default to `{ countSwitchAsVisit: true }` when storage is empty.
-- `setSettings` message persists to `chrome.storage.local`.
-- `getSettings` message returns current settings.
+- Default `settings.dailyTimeLimit` is `false`.
+- `setSettings` persists `dailyTimeLimit` to `chrome.storage.local`.
+- `getSettings` returns current settings.
+- `onActivated` in daily mode pauses the previous tab's timer and accumulates elapsed time.
+- `handleHostname` in daily mode redirects immediately when `dailyTimeSpent >= timeLimit`.
+- Storage keys include `dailyTimeSpent`.
 
 ---
 
@@ -232,12 +171,12 @@ if (switchToggle) {
 
 Not in scope now — candidates for this same settings tab later:
 
-| Setting | Key | Type | Default | Description |
-|---|---|---|---|---|
-| Daily reset time | `resetHour` | `number` (0–23) | `0` | Hour when visit counts and timers reset |
-| Grace period | `gracePeriodSeconds` | `number` | `0` | Extra seconds past limit before block triggers |
-| Show badge count | `showVisitBadge` | `boolean` | `true` | Show remaining visits on extension icon badge |
-| Snooze duration | `snoozeDurationMinutes` | `number` | `5` | How long "snooze" postpones the block page |
-| Block strictness | `blockStyle` | `'hard' \| 'soft'` | `'hard'` | `hard` = redirect, `soft` = overlay with "continue anyway" |
-| Pause all limits | `pauseAll` | `boolean` | `false` | Temporarily disable all tracking without deleting limits |
-| Notification before limit | `notifyBeforeLimit` | `boolean` | `false` | Browser notification when approaching a limit threshold |
+| Setting                   | Key                     | Type               | Default  | Description                                                |
+| ------------------------- | ----------------------- | ------------------ | -------- | ---------------------------------------------------------- |
+| Daily reset time          | `resetHour`             | `number` (0–23)    | `0`      | Hour when visit counts and timers reset                    |
+| Grace period              | `gracePeriodSeconds`    | `number`           | `0`      | Extra seconds past limit before block triggers             |
+| Show badge count          | `showVisitBadge`        | `boolean`          | `true`   | Show remaining visits on extension icon badge              |
+| Snooze duration           | `snoozeDurationMinutes` | `number`           | `5`      | How long "snooze" postpones the block page                 |
+| Block strictness          | `blockStyle`            | `'hard' \| 'soft'` | `'hard'` | `hard` = redirect, `soft` = overlay with "continue anyway" |
+| Pause all limits          | `pauseAll`              | `boolean`          | `false`  | Temporarily disable all tracking without deleting limits   |
+| Notification before limit | `notifyBeforeLimit`     | `boolean`          | `false`  | Browser notification when approaching a limit threshold    |

--- a/settings-tab-plan.md
+++ b/settings-tab-plan.md
@@ -1,0 +1,243 @@
+# Settings Tab — Implementation Plan
+
+## Motivation
+
+Both `chrome.tabs.onUpdated` (URL navigation) and `chrome.tabs.onActivated` (tab switching) call `handleHostname()`, which increments `visitCounts[hostname]` whenever `lastHandle[tabID] != hostname`.
+
+This means switching to an already-open tab can count as a new visit. Additionally, because `lastHandle` is in-memory only, any MV3 service worker restart resets it — so the very next tab activation after a restart counts as a fresh visit even without any navigation.
+
+Users should be able to choose what counts as a visit: new URL navigations only, or tab switches too.
+
+---
+
+## New Setting
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `countSwitchAsVisit` | `boolean` | **`true`** | When `false`, switching to an existing tab does **not** count as a new visit and does **not** restart the timer. Only navigating to a new URL (via `onUpdated`) triggers `handleHostname()`. |
+
+**Scope:** Global (applies to all tracked hostnames).
+
+---
+
+## Behavior Alignment
+
+Both visit counting and timer start share the **same** guard condition in `handleHostname()` ([background.ts:196-218](src/background/background.ts#L196-L218)):
+
+```ts
+// visit counting
+if (visitLimits[hostname] && lastHandle[tabID] != hostname) {
+  visitCounts[hostname]++;
+}
+// timer start
+if (timeLimits[hostname] && lastHandle[tabID] !== hostname) {
+  setTimerForTab(tabID, hostname, timeLimit);
+}
+```
+
+Because both use the same `lastHandle` check, the setting controls **both** in one shot:
+- `countSwitchAsVisit = false` → `onActivated` **skips** `handleHostname()` entirely → no visit increment, no timer restart on tab switch.
+- `countSwitchAsVisit = true` → `onActivated` calls `handleHostname()` as it does today → visit count and timer both fire on switch.
+
+Timers are already persisted via `timerStartTimes` in storage and restored on service-worker wake by `restoreTimers()` ([background.ts:169-191](src/background/background.ts#L169-L191)), so skipping `handleHostname()` on activation doesn't break ongoing time tracking.
+
+---
+
+## Implementation Steps
+
+### 1. Types — `src/background/background.ts` (local interfaces)
+
+`StorageData` and `MessageRequest` are defined **locally** in [background.ts:28-40](src/background/background.ts#L28-L40), not in `types.ts`.
+
+Add a `Settings` interface and update `StorageData`:
+
+```ts
+interface Settings {
+  countSwitchAsVisit: boolean;
+}
+
+const DEFAULT_SETTINGS: Settings = { countSwitchAsVisit: true };
+```
+
+Add `settings?: Settings` to `StorageData`.
+
+Also export `Settings` from `src/shared/types.ts` so the popup can use it for the message response type.
+
+### 2. Background state — `src/background/background.ts`
+
+Add a module-level variable after the existing state declarations (line ~60):
+
+```ts
+let settings: Settings = { ...DEFAULT_SETTINGS };
+```
+
+#### 2a. Load settings on startup
+
+Update `initializeFromStorage()` ([background.ts:65-106](src/background/background.ts#L65-L106)) to include `'settings'` in the keys array:
+
+```ts
+chrome.storage.local.get(
+  ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes', 'settings'],
+  ...
+)
+```
+
+And in the result handler:
+
+```ts
+if (result && result.settings) Object.assign(settings, result.settings);
+```
+
+> **Do NOT add settings to `updateStorage()`** — settings rarely change (user action only), while `updateStorage()` runs on every timer tick. Keep them separate.
+
+#### 2b. Guard `onActivated`
+
+In `chrome.tabs.onActivated` ([background.ts:309-325](src/background/background.ts#L309-L325)):
+
+```ts
+chrome.tabs.onActivated.addListener(async (activeInfo) => {
+  try {
+    await initializeFromStorage();
+    if (!settings.countSwitchAsVisit) return;   // ← new guard
+
+    chrome.tabs.get(activeInfo.tabId, (tab) => {
+      if (typeof tab.pendingUrl == 'undefined' && tab.url && tab.id) {
+        const hostname = extractHostname(tab.url);
+        handleHostname(hostname, tab.id);
+      }
+    });
+  } catch (error) {
+    console.log("Can't handle in onActivated:", error);
+  }
+});
+```
+
+#### 2c. Message handlers
+
+Add to the `switch` in `onMessage` ([background.ts:338-430](src/background/background.ts#L338-L430)):
+
+```ts
+case 'getSettings': {
+  sendResponse({ settings });
+  break;
+}
+
+case 'setSettings': {
+  if (request.settings) {
+    Object.assign(settings, request.settings);
+    chrome.storage.local.set({ settings });
+  }
+  sendResponse({ success: true });
+  break;
+}
+```
+
+Update `MessageRequest` to accept an optional `settings` field:
+
+```ts
+interface MessageRequest {
+  type: string;
+  hostname?: string;
+  visitLimit?: number;
+  timeLimit?: number;
+  settings?: Settings;   // ← add
+}
+```
+
+### 3. Popup UI — `public/popup.html`
+
+Add a 4th tab button to the `<nav>` (after "All Limits", [popup.html:48-52](public/popup.html#L48-L52)):
+
+```html
+<button class="tab-btn" data-tab="settings">
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+       stroke="currentColor" stroke-width="2">
+    <circle cx="12" cy="12" r="3"/>
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l..."/>  <!-- gear icon -->
+  </svg>
+</button>
+```
+
+Add the settings panel (after the "all-limits" div, [popup.html:210](public/popup.html#L210)):
+
+```html
+<!-- Settings Tab -->
+<div id="settings" class="tab-content">
+  <div class="settings-container">
+    <h3 class="settings-title">Settings</h3>
+    <div class="setting-row">
+      <div class="setting-info">
+        <span class="setting-label">Count tab switch as new visit</span>
+        <span class="setting-desc">When off, only navigating to a URL counts as a visit</span>
+      </div>
+      <label class="toggle">
+        <input type="checkbox" id="countSwitchAsVisit" />
+        <span class="toggle-slider"></span>
+      </label>
+    </div>
+  </div>
+</div>
+```
+
+Existing tab system in `initTabs()` ([popup.ts:10-34](src/popup/popup.ts#L10-L34)) already handles any `data-tab` / `.tab-content` pairs — no JS change needed for tab switching itself.
+
+### 4. Popup logic — `src/popup/popup.ts`
+
+Add a `loadSettings()` function and a change listener:
+
+```ts
+async function loadSettings(): Promise<void> {
+  const response = await chrome.runtime.sendMessage({ type: 'getSettings' });
+  const toggle = document.getElementById('countSwitchAsVisit') as HTMLInputElement;
+  if (toggle && response?.settings) {
+    toggle.checked = response.settings.countSwitchAsVisit;
+  }
+}
+```
+
+Wire it up in `initTabs()` — when `targetTab === 'settings'`, call `loadSettings()`.
+
+Add toggle change handler in `DOMContentLoaded`:
+
+```ts
+const switchToggle = document.getElementById('countSwitchAsVisit') as HTMLInputElement;
+if (switchToggle) {
+  switchToggle.addEventListener('change', () => {
+    chrome.runtime.sendMessage({
+      type: 'setSettings',
+      settings: { countSwitchAsVisit: switchToggle.checked },
+    });
+  });
+}
+```
+
+### 5. Styles — `public/popup.css`
+
+- `.settings-container`, `.setting-row` (flex row with space-between)
+- `.setting-label`, `.setting-desc` (text styles)
+- `.toggle` / `.toggle-slider` (CSS-only toggle switch)
+- Use existing theme variables (`--bg`, `--text`, `--border`, etc.) — no new colors needed.
+
+### 6. Tests — `__tests__/`
+
+- `onActivated` skips `handleHostname()` when `countSwitchAsVisit = false`.
+- `onActivated` calls `handleHostname()` when `countSwitchAsVisit = true` (default).
+- Settings default to `{ countSwitchAsVisit: true }` when storage is empty.
+- `setSettings` message persists to `chrome.storage.local`.
+- `getSettings` message returns current settings.
+
+---
+
+## Future / Optional Settings
+
+Not in scope now — candidates for this same settings tab later:
+
+| Setting | Key | Type | Default | Description |
+|---|---|---|---|---|
+| Daily reset time | `resetHour` | `number` (0–23) | `0` | Hour when visit counts and timers reset |
+| Grace period | `gracePeriodSeconds` | `number` | `0` | Extra seconds past limit before block triggers |
+| Show badge count | `showVisitBadge` | `boolean` | `true` | Show remaining visits on extension icon badge |
+| Snooze duration | `snoozeDurationMinutes` | `number` | `5` | How long "snooze" postpones the block page |
+| Block strictness | `blockStyle` | `'hard' \| 'soft'` | `'hard'` | `hard` = redirect, `soft` = overlay with "continue anyway" |
+| Pause all limits | `pauseAll` | `boolean` | `false` | Temporarily disable all tracking without deleting limits |
+| Notification before limit | `notifyBeforeLimit` | `boolean` | `false` | Browser notification when approaching a limit threshold |

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -26,16 +26,21 @@ interface TimerStartTimes {
 }
 
 interface Settings {
-  countSwitchAsVisit: boolean;
+  dailyTimeLimit: boolean;
 }
 
-const DEFAULT_SETTINGS: Settings = { countSwitchAsVisit: true };
+const DEFAULT_SETTINGS: Settings = { dailyTimeLimit: false };
+
+interface DailyTimeSpent {
+  [hostname: string]: number;
+}
 
 interface StorageData {
   timeLimits?: Limits;
   visitLimits?: Limits;
   visitCounts?: VisitCounts;
   timerStartTimes?: TimerStartTimes;
+  dailyTimeSpent?: DailyTimeSpent;
   settings?: Settings;
 }
 
@@ -44,7 +49,7 @@ interface MessageRequest {
   hostname?: string;
   visitLimit?: number;
   timeLimit?: number;
-  settings?: Settings;
+  settings?: Partial<Settings>;
 }
 
 interface StatItem {
@@ -66,8 +71,13 @@ const visitLimits: Limits = {};
 const timers: Timers = {};
 const lastHandle: LastHandle = {};
 const timerStartTimes: TimerStartTimes = {};
+const dailyTimeSpent: DailyTimeSpent = {};
+const settings: Settings = { ...DEFAULT_SETTINGS };
 
-let settings: Settings = { ...DEFAULT_SETTINGS };
+const DAILY_RESET_ALARM = 'dailyResetAlarm';
+const MS_IN_MINUTE = 60000;
+
+let currentActiveTabId: number | null = null;
 
 let isInitialized: boolean = false;
 let initializationPromise: Promise<void> | null = null;
@@ -78,7 +88,7 @@ async function initializeFromStorage(): Promise<void> {
 
   initializationPromise = new Promise((resolve, reject) => {
     chrome.storage.local.get(
-      ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes', 'settings'],
+      ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes', 'dailyTimeSpent', 'settings'],
       (result: StorageData) => {
         if (chrome.runtime.lastError) {
           console.error('Error loading data from storage:', chrome.runtime.lastError);
@@ -94,6 +104,7 @@ async function initializeFromStorage(): Promise<void> {
           if (result && result.visitCounts) Object.assign(visitCounts, result.visitCounts);
           if (result && result.timerStartTimes)
             Object.assign(timerStartTimes, result.timerStartTimes);
+          if (result && result.dailyTimeSpent) Object.assign(dailyTimeSpent, result.dailyTimeSpent);
           if (result && result.settings) Object.assign(settings, result.settings);
           console.log('Loaded persisted data from storage:', {
             timeLimits,
@@ -141,11 +152,14 @@ function setTimerForTab(
   };
 
   const timer = setTimeout(() => {
+    if (settings.dailyTimeLimit && timeLimits[hostname] !== undefined) {
+      dailyTimeSpent[hostname] = timeLimits[hostname] * MS_IN_MINUTE;
+    }
     delete timers[tabID];
     delete timerStartTimes[tabID];
     updateStorage();
     redirectTabToTimeExceeded(tabID);
-  }, remainingMinutes * 60000);
+  }, remainingMinutes * MS_IN_MINUTE);
   timers[tabID] = timer;
   updateStorage();
   return timer;
@@ -153,7 +167,7 @@ function setTimerForTab(
 
 function calculateRemainingTime(startTime: number, timeLimit: number): number {
   const now = Date.now();
-  const elapsed = (now - startTime) / 60000; // minutes
+  const elapsed = (now - startTime) / MS_IN_MINUTE;
   return timeLimit - elapsed;
 }
 
@@ -191,11 +205,28 @@ async function restoreTimers(): Promise<void> {
       continue;
     }
 
-    const result = resumeOrExpireTimer(tabID, hostname, timeLimit, startTime);
-    if (result.resumed) {
-      console.log(
-        `Restored timer for ${hostname} on tabId: ${tabID}, ${result.remaining.toFixed(2)} minutes remaining`
-      );
+    if (settings.dailyTimeLimit) {
+      // Accumulate elapsed time from the interrupted session segment
+      const elapsed = Date.now() - startTime;
+      dailyTimeSpent[hostname] = (dailyTimeSpent[hostname] || 0) + elapsed;
+      delete timerStartTimes[tabID];
+
+      const remainingMs = timeLimit * MS_IN_MINUTE - dailyTimeSpent[hostname];
+      if (remainingMs > 0) {
+        setTimerForTab(tabID, hostname, remainingMs / MS_IN_MINUTE);
+        console.log(
+          `Restored daily timer for ${hostname} on tabId: ${tabID}, ${(remainingMs / MS_IN_MINUTE).toFixed(2)} minutes remaining`
+        );
+      } else {
+        redirectTabToTimeExceeded(tabID);
+      }
+    } else {
+      const result = resumeOrExpireTimer(tabID, hostname, timeLimit, startTime);
+      if (result.resumed) {
+        console.log(
+          `Restored timer for ${hostname} on tabId: ${tabID}, ${result.remaining.toFixed(2)} minutes remaining`
+        );
+      }
     }
   }
   updateStorage();
@@ -220,10 +251,29 @@ function handleHostname(hostname: string, tabID: number): void {
     }
   }
 
-  if (timeLimits[hostname] && lastHandle[tabID] !== hostname) {
-    const timeLimit = timeLimits[hostname];
-    setTimerForTab(tabID, hostname, timeLimit);
-    console.log(`New timer set for ${hostname} on tabId: ${tabID} for ${timeLimit} minutes`);
+  if (timeLimits[hostname]) {
+    if (settings.dailyTimeLimit) {
+      // All-day mode: only start timer when no timer is already running for this tab
+      if (!timers[tabID]) {
+        const spentMs = dailyTimeSpent[hostname] || 0;
+        const remainingMs = timeLimits[hostname] * MS_IN_MINUTE - spentMs;
+        if (remainingMs <= 0) {
+          console.log(`Daily time limit exceeded for ${hostname} on tabId: ${tabID}`);
+          redirectTabToTimeExceeded(tabID);
+          return;
+        }
+        setTimerForTab(tabID, hostname, remainingMs / MS_IN_MINUTE);
+        console.log(
+          `Daily timer set for ${hostname} on tabId: ${tabID}, ${(remainingMs / MS_IN_MINUTE).toFixed(2)} minutes remaining`
+        );
+      }
+    } else if (lastHandle[tabID] !== hostname) {
+      // Per-visit mode: fresh timer on each new visit
+      setTimerForTab(tabID, hostname, timeLimits[hostname]);
+      console.log(
+        `New timer set for ${hostname} on tabId: ${tabID} for ${timeLimits[hostname]} minutes`
+      );
+    }
   }
   if (timeLimits[hostname] || visitLimits[hostname]) {
     lastHandle[tabID] = hostname;
@@ -267,10 +317,12 @@ function updateStorage(): void {
   try {
     chrome.storage.local.set(
       {
+        settings: settings,
         timeLimits: timeLimits,
         visitLimits: visitLimits,
         visitCounts: visitCounts,
         timerStartTimes: timerStartTimes,
+        dailyTimeSpent: dailyTimeSpent,
       },
       () => {
         if (chrome.runtime.lastError) {
@@ -281,6 +333,7 @@ function updateStorage(): void {
             visitLimits,
             visitCounts,
             timerStartTimes,
+            dailyTimeSpent,
           });
         }
       }
@@ -301,6 +354,11 @@ chrome.tabs.onUpdated.addListener(
       console.log(`Tab with id: ${tabId} was updated. New url: ${changeInfo.url}`);
 
       if (timers[tabId] && lastHandle[tabId] && lastHandle[tabId] !== hostname) {
+        if (settings.dailyTimeLimit && timerStartTimes[tabId]) {
+          const elapsed = Date.now() - timerStartTimes[tabId].startTime;
+          dailyTimeSpent[timerStartTimes[tabId].hostname] =
+            (dailyTimeSpent[timerStartTimes[tabId].hostname] || 0) + elapsed;
+        }
         clearTimeout(timers[tabId]);
         delete timers[tabId];
         delete timerStartTimes[tabId];
@@ -320,7 +378,29 @@ chrome.tabs.onUpdated.addListener(
 chrome.tabs.onActivated.addListener(async (activeInfo: chrome.tabs.TabActiveInfo) => {
   try {
     await initializeFromStorage();
-    if (!settings.countSwitchAsVisit) return;
+
+    // All-day mode: pause the timer on the tab we're switching away from
+    if (
+      settings.dailyTimeLimit &&
+      currentActiveTabId !== null &&
+      currentActiveTabId !== activeInfo.tabId
+    ) {
+      const prevTabId = currentActiveTabId;
+      if (timerStartTimes[prevTabId]) {
+        const { hostname, startTime } = timerStartTimes[prevTabId];
+        const elapsed = Date.now() - startTime;
+        dailyTimeSpent[hostname] = (dailyTimeSpent[hostname] || 0) + elapsed;
+        clearTimeout(timers[prevTabId]);
+        delete timers[prevTabId];
+        delete timerStartTimes[prevTabId];
+        console.log(
+          `Paused daily timer for ${hostname} on tab ${prevTabId}, accumulated ${elapsed}ms`
+        );
+        updateStorage();
+      }
+    }
+
+    currentActiveTabId = activeInfo.tabId;
 
     chrome.tabs.get(activeInfo.tabId, (tab: chrome.tabs.Tab) => {
       if (typeof tab.pendingUrl == 'undefined' && tab.url && tab.id) {
@@ -430,7 +510,7 @@ chrome.runtime.onMessage.addListener(
           case 'setSettings': {
             if (request.settings) {
               Object.assign(settings, request.settings);
-              chrome.storage.local.set({ settings });
+              updateStorage();
             }
             sendResponse({ success: true });
             break;
@@ -466,8 +546,6 @@ chrome.runtime.onMessage.addListener(
   }
 );
 
-const DAILY_RESET_ALARM = 'dailyResetAlarm';
-
 async function setupDailyResetAlarm(): Promise<void> {
   try {
     await initializeFromStorage();
@@ -494,6 +572,7 @@ chrome.alarms.onAlarm.addListener(async (alarm: chrome.alarms.Alarm) => {
       console.log('Daily reset triggered at', new Date().toLocaleString());
 
       for (const member in visitCounts) delete visitCounts[member];
+      for (const member in dailyTimeSpent) delete dailyTimeSpent[member];
       for (const tabID in timers) {
         clearTimeout(timers[tabID]);
         delete timers[tabID];

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -25,11 +25,18 @@ interface TimerStartTimes {
   [tabId: string]: TimerStartTime;
 }
 
+interface Settings {
+  countSwitchAsVisit: boolean;
+}
+
+const DEFAULT_SETTINGS: Settings = { countSwitchAsVisit: true };
+
 interface StorageData {
   timeLimits?: Limits;
   visitLimits?: Limits;
   visitCounts?: VisitCounts;
   timerStartTimes?: TimerStartTimes;
+  settings?: Settings;
 }
 
 interface MessageRequest {
@@ -37,6 +44,7 @@ interface MessageRequest {
   hostname?: string;
   visitLimit?: number;
   timeLimit?: number;
+  settings?: Settings;
 }
 
 interface StatItem {
@@ -59,6 +67,8 @@ const timers: Timers = {};
 const lastHandle: LastHandle = {};
 const timerStartTimes: TimerStartTimes = {};
 
+let settings: Settings = { ...DEFAULT_SETTINGS };
+
 let isInitialized: boolean = false;
 let initializationPromise: Promise<void> | null = null;
 
@@ -68,7 +78,7 @@ async function initializeFromStorage(): Promise<void> {
 
   initializationPromise = new Promise((resolve, reject) => {
     chrome.storage.local.get(
-      ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes'],
+      ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes', 'settings'],
       (result: StorageData) => {
         if (chrome.runtime.lastError) {
           console.error('Error loading data from storage:', chrome.runtime.lastError);
@@ -84,6 +94,7 @@ async function initializeFromStorage(): Promise<void> {
           if (result && result.visitCounts) Object.assign(visitCounts, result.visitCounts);
           if (result && result.timerStartTimes)
             Object.assign(timerStartTimes, result.timerStartTimes);
+          if (result && result.settings) Object.assign(settings, result.settings);
           console.log('Loaded persisted data from storage:', {
             timeLimits,
             visitLimits,
@@ -309,6 +320,7 @@ chrome.tabs.onUpdated.addListener(
 chrome.tabs.onActivated.addListener(async (activeInfo: chrome.tabs.TabActiveInfo) => {
   try {
     await initializeFromStorage();
+    if (!settings.countSwitchAsVisit) return;
 
     chrome.tabs.get(activeInfo.tabId, (tab: chrome.tabs.Tab) => {
       if (typeof tab.pendingUrl == 'undefined' && tab.url && tab.id) {
@@ -407,6 +419,20 @@ chrome.runtime.onMessage.addListener(
             });
 
             sendResponse({ stats });
+            break;
+          }
+
+          case 'getSettings': {
+            sendResponse({ settings });
+            break;
+          }
+
+          case 'setSettings': {
+            if (request.settings) {
+              Object.assign(settings, request.settings);
+              chrome.storage.local.set({ settings });
+            }
+            sendResponse({ success: true });
             break;
           }
 

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -329,6 +329,7 @@ function updateStorage(): void {
           console.error('Error saving data to storage:', chrome.runtime.lastError);
         } else {
           console.log('Saved data to storage:', {
+            settings,
             timeLimits,
             visitLimits,
             visitCounts,
@@ -403,7 +404,7 @@ chrome.tabs.onActivated.addListener(async (activeInfo: chrome.tabs.TabActiveInfo
     currentActiveTabId = activeInfo.tabId;
 
     chrome.tabs.get(activeInfo.tabId, (tab: chrome.tabs.Tab) => {
-      if (typeof tab.pendingUrl == 'undefined' && tab.url && tab.id) {
+      if (tab && typeof tab.pendingUrl == 'undefined' && tab.url && tab.id) {
         const hostname = extractHostname(tab.url);
         console.log('tab switched hostname extractHostname: ', hostname, 'call handleHostname..');
         handleHostname(hostname, tab.id);

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -586,6 +586,8 @@ document.addEventListener('DOMContentLoaded', () => {
         settings: { dailyTimeLimit: dailyTimeLimitToggle.checked },
       });
     };
+    // TODO: Refactor to avoid duplicate code for click and keydown handlers.
+    // In this case setSettings set twice, not efficient but not a bug.
     dailyTimeLimitRow.addEventListener('click', () => {
       dailyTimeLimitToggle.checked = !dailyTimeLimitToggle.checked;
       sendDailyTimeLimitSetting();

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -5,6 +5,7 @@ import type {
   StatsResponse,
   LimitsResponse,
   DeLimitResponse,
+  SettingsResponse,
 } from '../shared/types.js';
 
 function initTabs(): void {
@@ -18,6 +19,7 @@ function initTabs(): void {
 
       tabButtons.forEach((btn) => btn.classList.remove('active'));
       tabContents.forEach((content) => content.classList.remove('active'));
+      document.getElementById('settingsBtn')?.classList.remove('active');
 
       button.classList.add('active');
       const targetElement = document.getElementById(targetTab);
@@ -181,6 +183,14 @@ async function loadStats(): Promise<void> {
   } catch (error) {
     console.error('Error loading stats:', error);
     statsContent.innerHTML = '<div class="error-state">Failed to load stats</div>';
+  }
+}
+
+async function loadSettings(): Promise<void> {
+  const response = (await chrome.runtime.sendMessage({ type: 'getSettings' })) as SettingsResponse;
+  const toggle = document.getElementById('countSwitchAsVisit') as HTMLInputElement;
+  if (toggle && response?.settings) {
+    toggle.checked = response.settings.countSwitchAsVisit;
   }
 }
 
@@ -540,9 +550,31 @@ document.addEventListener('DOMContentLoaded', () => {
   initLogoEasterEgg();
   startTipRotation();
 
+  const settingsBtn = document.getElementById('settingsBtn');
+  if (settingsBtn) {
+    settingsBtn.addEventListener('click', () => {
+      document.querySelectorAll<HTMLButtonElement>('.tab-btn').forEach((btn) => btn.classList.remove('active'));
+      document.querySelectorAll<HTMLElement>('.tab-content').forEach((c) => c.classList.remove('active'));
+      settingsBtn.classList.add('active');
+      const settingsPanel = document.getElementById('settings');
+      if (settingsPanel) settingsPanel.classList.add('active');
+      loadSettings();
+    });
+  }
+
   const themeToggle = document.getElementById('themeToggle');
   if (themeToggle) {
     themeToggle.addEventListener('click', toggleTheme);
+  }
+
+  const switchToggle = document.getElementById('countSwitchAsVisit') as HTMLInputElement;
+  if (switchToggle) {
+    switchToggle.addEventListener('change', () => {
+      chrome.runtime.sendMessage({
+        type: 'setSettings',
+        settings: { countSwitchAsVisit: switchToggle.checked },
+      });
+    });
   }
 
   const nextTipBtn = document.getElementById('nextTipBtn');

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -188,9 +188,9 @@ async function loadStats(): Promise<void> {
 
 async function loadSettings(): Promise<void> {
   const response = (await chrome.runtime.sendMessage({ type: 'getSettings' })) as SettingsResponse;
-  const toggle = document.getElementById('countSwitchAsVisit') as HTMLInputElement;
+  const toggle = document.getElementById('dailyTimeLimit') as HTMLInputElement;
   if (toggle && response?.settings) {
-    toggle.checked = response.settings.countSwitchAsVisit;
+    toggle.checked = response.settings.dailyTimeLimit;
   }
 }
 
@@ -553,8 +553,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const settingsBtn = document.getElementById('settingsBtn');
   if (settingsBtn) {
     settingsBtn.addEventListener('click', () => {
-      document.querySelectorAll<HTMLButtonElement>('.tab-btn').forEach((btn) => btn.classList.remove('active'));
-      document.querySelectorAll<HTMLElement>('.tab-content').forEach((c) => c.classList.remove('active'));
+      document
+        .querySelectorAll<HTMLButtonElement>('.tab-btn')
+        .forEach((btn) => btn.classList.remove('active'));
+      document
+        .querySelectorAll<HTMLElement>('.tab-content')
+        .forEach((c) => c.classList.remove('active'));
       settingsBtn.classList.add('active');
       const settingsPanel = document.getElementById('settings');
       if (settingsPanel) settingsPanel.classList.add('active');
@@ -565,15 +569,33 @@ document.addEventListener('DOMContentLoaded', () => {
   const themeToggle = document.getElementById('themeToggle');
   if (themeToggle) {
     themeToggle.addEventListener('click', toggleTheme);
+    themeToggle.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        toggleTheme();
+      }
+    });
   }
 
-  const switchToggle = document.getElementById('countSwitchAsVisit') as HTMLInputElement;
-  if (switchToggle) {
-    switchToggle.addEventListener('change', () => {
+  const dailyTimeLimitToggle = document.getElementById('dailyTimeLimit') as HTMLInputElement;
+  const dailyTimeLimitRow = document.getElementById('dailyTimeLimitRow');
+  if (dailyTimeLimitToggle && dailyTimeLimitRow) {
+    const sendDailyTimeLimitSetting = () => {
       chrome.runtime.sendMessage({
         type: 'setSettings',
-        settings: { countSwitchAsVisit: switchToggle.checked },
+        settings: { dailyTimeLimit: dailyTimeLimitToggle.checked },
       });
+    };
+    dailyTimeLimitRow.addEventListener('click', () => {
+      dailyTimeLimitToggle.checked = !dailyTimeLimitToggle.checked;
+      sendDailyTimeLimitSetting();
+    });
+    dailyTimeLimitRow.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        dailyTimeLimitToggle.checked = !dailyTimeLimitToggle.checked;
+        sendDailyTimeLimitSetting();
+      }
     });
   }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -24,11 +24,16 @@ export interface DeLimitResponse {
 }
 
 export interface Settings {
-  countSwitchAsVisit: boolean;
+  dailyTimeLimit: boolean;
 }
 
 export interface SettingsResponse {
   settings: Settings;
 }
 
-export type MessageResponse = StatsResponse | LimitsResponse | DeLimitResponse | SettingsResponse | void;
+export type MessageResponse =
+  | StatsResponse
+  | LimitsResponse
+  | DeLimitResponse
+  | SettingsResponse
+  | void;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -23,4 +23,12 @@ export interface DeLimitResponse {
   success: boolean;
 }
 
-export type MessageResponse = StatsResponse | LimitsResponse | DeLimitResponse | void;
+export interface Settings {
+  countSwitchAsVisit: boolean;
+}
+
+export interface SettingsResponse {
+  settings: Settings;
+}
+
+export type MessageResponse = StatsResponse | LimitsResponse | DeLimitResponse | SettingsResponse | void;


### PR DESCRIPTION
## Add Settings Tab with Daily Time Limit Mode

### Summary

- Replaces the header theme toggle button with a settings gear icon that opens a dedicated **Settings tab**
- Adds a **"Daily time limit"** toggle — when enabled, time limits are cumulative across the whole day rather than resetting on each new visit. The timer pauses when switching to another tab and resumes when switching back, accumulating towards the daily cap
- Moves the dark mode toggle into the Settings tab as a proper setting row
- Adds `getSettings` / `setSettings` message handlers in the background service worker, with persistence via `chrome.storage.local`
- Introduces a `Settings` interface (`{ dailyTimeLimit: boolean }`) in shared types and a `SettingsResponse` type for the message protocol
- Adds `dailyTimeSpent` storage key to track accumulated milliseconds per hostname across tab switches and service worker restarts

### Changes

| File | What changed |
|------|-------------|
| `src/shared/types.ts` | Added `Settings` (`dailyTimeLimit: boolean`) and `SettingsResponse` interfaces |
| `src/background/background.ts` | `dailyTimeSpent` accumulator, per-tab timer pause/resume on `onActivated`, daily-mode timer logic in `handleHostname`, `restoreTimers` accumulates interrupted sessions, `getSettings`/`setSettings` message handlers |
| `src/popup/popup.ts` | Settings tab navigation, `loadSettings()`, daily-time-limit toggle with row-click and keyboard handlers |
| `public/popup.html` | Settings tab panel with dark mode row and daily-time-limit toggle; header button replaced with gear icon |
| `public/popup.css` | Styles for settings container, setting rows, toggle switch, and active state for the gear button |
| `__tests__/background.test.ts` | Tests for new settings message handlers and `dailyTimeLimit` behavior |

### Behavior details

**Daily mode OFF (default):** Each new visit to a hostname starts a fresh timer. Switching tabs does not affect the countdown.

**Daily mode ON:** A single shared time budget per hostname per day. The timer pauses when the user switches away from the tab and resumes when they return. Elapsed time is flushed to `dailyTimeSpent` on pause and on service worker shutdown, so the budget survives restarts. The daily reset alarm clears `dailyTimeSpent` alongside visit counts at midnight.

## Demo
<img width="316" height="357" alt="image" src="https://github.com/user-attachments/assets/d1ba7546-9759-4952-abc4-ea47272449fc" />
