### PR TITLE
feat: Add Time Left tab + fix timer lifecycle bugs (focus loss, tab close, MV3 reset)

### DIFF
--- a/__tests__/background.test.ts
+++ b/__tests__/background.test.ts
@@ -17,6 +17,7 @@ interface MockStorageData {
   timerStartTimes?: Record<string, { hostname: string; startTime: number }>;
   dailyTimeSpent?: Record<string, number>;
   settings?: MockSettings;
+  lastDailyResetDate?: string;
 }
 
 interface MockTab {
@@ -42,6 +43,8 @@ type TabsOnUpdatedListener = (
 ) => void | Promise<void>;
 
 type TabsOnActivatedListener = (activeInfo: { tabId: number }) => void | Promise<void>;
+type TabsOnRemovedListener = (tabId: number) => void | Promise<void>;
+type WindowsOnFocusChangedListener = (windowId: number) => void | Promise<void>;
 
 type AlarmListener = (alarm: MockAlarm) => void | Promise<void>;
 
@@ -66,9 +69,16 @@ declare const global: typeof globalThis & {
       onActivated: {
         addListener: jest.MockedFunction<(listener: TabsOnActivatedListener) => void>;
       };
+      onRemoved: { addListener: jest.MockedFunction<(listener: TabsOnRemovedListener) => void> };
       update: typeof mockTabsUpdate;
       get: typeof mockTabsGet;
       query: typeof mockTabsQuery;
+    };
+    windows: {
+      WINDOW_ID_NONE: number;
+      onFocusChanged: {
+        addListener: jest.MockedFunction<(listener: WindowsOnFocusChangedListener) => void>;
+      };
     };
     runtime: {
       onMessage: { addListener: jest.MockedFunction<(listener: MessageListener) => void> };
@@ -93,9 +103,14 @@ Object.defineProperty(global, 'chrome', {
     tabs: {
       onUpdated: { addListener: jest.fn() },
       onActivated: { addListener: jest.fn() },
+      onRemoved: { addListener: jest.fn() },
       update: mockTabsUpdate,
       get: mockTabsGet,
       query: mockTabsQuery,
+    },
+    windows: {
+      WINDOW_ID_NONE: -1,
+      onFocusChanged: { addListener: jest.fn() },
     },
     runtime: {
       onMessage: { addListener: jest.fn() },
@@ -137,7 +152,15 @@ describe('Background Script', () => {
     alarmListener = global.chrome.alarms.onAlarm.addListener.mock.calls[0][0];
 
     expect(global.chrome.storage.local.get).toHaveBeenCalledWith(
-      ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes', 'dailyTimeSpent', 'settings'],
+      [
+        'timeLimits',
+        'visitLimits',
+        'visitCounts',
+        'timerStartTimes',
+        'dailyTimeSpent',
+        'settings',
+        'lastDailyResetDate',
+      ],
       expect.any(Function)
     );
   });
@@ -187,6 +210,7 @@ describe('Background Script', () => {
           'timerStartTimes',
           'dailyTimeSpent',
           'settings',
+          'lastDailyResetDate',
         ],
         expect.any(Function)
       );
@@ -525,9 +549,7 @@ describe('Background Script', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       const logMessages = consoleSpy.mock.calls.map((call) => call.join(' '));
-      expect(logMessages.some((msg) => msg.includes(`Paused daily timer for ${hostname}`))).toBe(
-        true
-      );
+      expect(logMessages.some((msg) => msg.includes(`Paused timer for ${hostname}`))).toBe(true);
 
       consoleSpy.mockRestore();
 
@@ -608,6 +630,54 @@ describe('Background Script', () => {
       ).toBe(true);
 
       consoleSpy.mockRestore();
+    });
+
+    test('should refresh daily time budgets at midnight before exhaustion', async () => {
+      const hostname = `dailyrefresh${Date.now()}.com`;
+      messageListener({ type: 'setSettings', settings: { dailyTimeLimit: true } }, {}, jest.fn());
+      messageListener({ type: 'setTimeLimit', hostname, timeLimit: 30 }, {}, jest.fn());
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      mockTabsGet.mockImplementation((...args: unknown[]) => {
+        const tabId = args[0] as number;
+        const callback = args[1] as (tab: MockTab) => void;
+        callback(
+          tabId === 300
+            ? { id: 300, url: `https://${hostname}`, pendingUrl: undefined }
+            : { id: tabId, url: 'https://other.com', pendingUrl: undefined }
+        );
+      });
+      await onActivatedListener({ tabId: 300 });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await onActivatedListener({ tabId: 301 });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const currentDate = new Date();
+      const currentDateKey = `${currentDate.getFullYear()}-${String(currentDate.getMonth() + 1).padStart(2, '0')}-${String(currentDate.getDate()).padStart(2, '0')}`;
+
+      mockStorageSet.mockClear();
+      await alarmListener({ name: 'dailyResetAlarm' });
+
+      const resetPayload = mockStorageSet.mock.calls.find((call) => {
+        const payload = call[0] as MockStorageData;
+        return payload.lastDailyResetDate === currentDateKey;
+      })?.[0] as MockStorageData | undefined;
+
+      expect(resetPayload?.dailyTimeSpent?.[hostname]).toBeUndefined();
+
+      const sendResponse = jest.fn();
+      messageListener({ type: 'getTimeLeft' }, {}, sendResponse);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const response = sendResponse.mock.calls[0][0] as {
+        timeLeft: Array<{ hostname: string; remainingMs: number; spentMs: number }>;
+      };
+      const timeLeft = response.timeLeft.find((item) => item.hostname === hostname);
+
+      expect(timeLeft).toMatchObject({ remainingMs: 30 * 60000, spentMs: 0 });
+
+      messageListener({ type: 'setSettings', settings: { dailyTimeLimit: false } }, {}, jest.fn());
+      await new Promise((resolve) => setTimeout(resolve, 50));
     });
 
     test('should ignore non-reset alarms', async () => {

--- a/__tests__/popup.test.ts
+++ b/__tests__/popup.test.ts
@@ -59,6 +59,7 @@ describe('LiLimit Popup', () => {
     await import(`../src/popup/popup.ts?t=${Date.now()}`);
 
     document.dispatchEvent(new Event('DOMContentLoaded'));
+    mockChrome.runtime.sendMessage.mockClear();
   });
 
   afterEach(() => {
@@ -167,12 +168,14 @@ describe('LiLimit Popup', () => {
   });
 
   describe('Tab Switching', () => {
-    test('should initialize with Set Limits tab active', () => {
+    test('should initialize with Time Left tab active', () => {
+      const timeLeftTab = document.getElementById('time-left') as HTMLElement;
       const setLimitsTab = document.getElementById('set-limits') as HTMLElement;
       const statsTab = document.getElementById('stats') as HTMLElement;
       const allLimitsTab = document.getElementById('all-limits') as HTMLElement;
 
-      expect(setLimitsTab.classList.contains('active')).toBe(true);
+      expect(timeLeftTab.classList.contains('active')).toBe(true);
+      expect(setLimitsTab.classList.contains('active')).toBe(false);
       expect(statsTab.classList.contains('active')).toBe(false);
       expect(allLimitsTab.classList.contains('active')).toBe(false);
     });
@@ -330,9 +333,44 @@ describe('LiLimit Popup', () => {
       await Promise.resolve();
 
       const limitsContent = document.getElementById('limitsContent') as HTMLElement;
+      const timeLimitInput = limitsContent.querySelector('.limit-time-input') as HTMLInputElement;
       expect(limitsContent.innerHTML).toContain('example.com');
-      expect(limitsContent.innerHTML).toContain('30 minutes per visit');
+      expect(timeLimitInput.value).toBe('30');
+      expect(limitsContent.innerHTML).toContain('minutes per visit');
       expect(limitsContent.innerHTML).toContain('5 visits per day');
+    });
+
+    test('should update a time limit from the all limits card', async () => {
+      const allLimitsButton = document.querySelector(
+        '[data-tab="all-limits"]'
+      ) as HTMLButtonElement;
+      mockChrome.runtime.sendMessage.mockResolvedValue({
+        limits: [{ hostname: 'example.com', timeLimit: 30, visitLimit: 5 }],
+      });
+
+      allLimitsButton.click();
+      await Promise.resolve();
+
+      mockChrome.runtime.sendMessage.mockClear();
+      mockChrome.runtime.sendMessage.mockResolvedValue({ success: true });
+
+      const timeLimitInput = document.querySelector('.limit-time-input') as HTMLInputElement;
+      const saveButton = document.querySelector('.save-limit-btn') as HTMLButtonElement;
+
+      timeLimitInput.value = '45';
+      saveButton.click();
+
+      await Promise.resolve();
+
+      expect(mockChrome.runtime.sendMessage).toHaveBeenCalledWith({
+        type: 'setTimeLimit',
+        hostname: 'example.com',
+        timeLimit: 45,
+      });
+      expect((document.querySelector('.limit-time-input') as HTMLInputElement).value).toBe('45');
+      expect(document.getElementById('message')?.textContent).toBe(
+        'Time limit updated for example.com'
+      );
     });
 
     test('should display multiple limit cards', async () => {

--- a/public/popup.css
+++ b/public/popup.css
@@ -586,6 +586,18 @@ input[type='number']:focus::-webkit-outer-spin-button {
   transform: translateX(-1px);
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .limit-details {
   display: flex;
   flex-direction: column;
@@ -608,6 +620,55 @@ input[type='number']:focus::-webkit-outer-spin-button {
   color: var(--accent);
   opacity: 0.7;
   flex-shrink: 0;
+}
+
+.limit-edit-row {
+  gap: 6px;
+}
+
+.limit-edit-label {
+  flex: 0 0 58px;
+}
+
+.limit-time-input {
+  width: 100%;
+  padding: 4px 6px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  font-size: 12px;
+  outline: none;
+}
+
+.limit-time-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(110, 231, 183, 0.1);
+}
+
+.limit-edit-unit {
+  flex: 1;
+}
+
+.save-limit-btn {
+  border: 1px solid rgba(110, 231, 183, 0.25);
+  background: rgba(110, 231, 183, 0.1);
+  color: var(--accent);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.save-limit-btn:hover {
+  background: rgba(110, 231, 183, 0.18);
+}
+
+.save-limit-btn:disabled {
+  cursor: wait;
+  opacity: 0.6;
 }
 
 .delete-limit-btn {

--- a/public/popup.css
+++ b/public/popup.css
@@ -1014,3 +1014,174 @@ input[type='number']:focus::-webkit-outer-spin-button {
   opacity: 0;
   transform: rotate(-180deg) scale(0.5);
 }
+
+
+.time-left-container {
+  background: var(--card-bg);
+  border-radius: var(--radius);
+  padding: 12px;
+  box-shadow: 0 6px 18px rgba(2, 6, 23, 0.6);
+  border: 1px solid var(--border);
+  max-height: 400px;
+  overflow-y: auto;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+[data-theme='light'] .time-left-container {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.time-left-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.time-left-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+  color: var(--text);
+}
+
+.time-left-content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.time-left-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+  animation: slideInCard 0.4s cubic-bezier(0.4, 0, 0.2, 1) backwards;
+}
+
+.time-left-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-dark));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.time-left-card:hover {
+  background: var(--hover-bg);
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+}
+
+.time-left-card:hover::before {
+  transform: scaleX(1);
+}
+
+[data-theme='light'] .time-left-card:hover {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+.time-left-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.time-left-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: linear-gradient(135deg, rgba(110, 231, 183, 0.2), rgba(77, 214, 161, 0.1));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.time-left-hostname {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.time-left-status {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.time-left-status.active {
+  color: var(--accent);
+}
+
+.time-left-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.time-left-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.time-left-label svg {
+  opacity: 0.6;
+}
+
+.time-left-value {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.time-left-value.exhausted {
+  color: var(--danger);
+}
+
+.time-left-progress-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.time-left-container::-webkit-scrollbar {
+  width: 6px;
+}
+
+.time-left-container::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 3px;
+}
+
+.time-left-container::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+}
+
+.time-left-container::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.15);
+}

--- a/public/popup.html
+++ b/public/popup.html
@@ -29,12 +29,52 @@
       </header>
 
       <nav class="tabs">
-        <button class="tab-btn active" data-tab="set-limits">Set Limits</button>
+        <button class="tab-btn active" data-tab="time-left">Time Left</button>
+        <button class="tab-btn" data-tab="set-limits">Set Limits</button>
         <button class="tab-btn" data-tab="stats">Live Stats</button>
         <button class="tab-btn" data-tab="all-limits">All Limits</button>
       </nav>
 
-      <div id="set-limits" class="tab-content active">
+      <!-- Time Left Tab -->
+      <div id="time-left" class="tab-content active">
+        <div class="time-left-container">
+          <div class="time-left-header">
+            <h3 class="time-left-title">Time Left Today</h3>
+            <button id="refreshTimeLeft" class="icon-btn" aria-label="Refresh time left">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <path
+                  d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"
+                />
+              </svg>
+            </button>
+          </div>
+          <div id="timeLeftContent" class="time-left-content">
+            <div class="empty-state">
+              <svg
+                width="48"
+                height="48"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path d="M12 6v6l4 2" />
+              </svg>
+              <p>No time budgets set yet</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div id="set-limits" class="tab-content">
         <form id="limitsForm" class="form" autocomplete="off">
           <div class="form-header">
             <label for="hostname" class="label">Website (URL or hostname)</label>

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -209,6 +209,7 @@ function pauseTimerForTab(tabID: string | number): void {
   }
   clearTimeout(timers[tabID]);
   delete timers[tabID];
+  delete timerStartTimes[tabID];
   updateStorage();
 }
 
@@ -513,17 +514,21 @@ chrome.windows.onFocusChanged.addListener(async (windowId: number) => {
         pauseTimerForTab(currentActiveTabId);
       }
     } else {
-      // Chrome regained focus — resume the active tab's timer if limited.
-      if (currentActiveTabId !== null) {
-        try {
-          const tab = await chrome.tabs.get(currentActiveTabId);
-          if (tab && tab.url && tab.id) {
-            const hostname = extractHostname(tab.url);
-            handleHostname(hostname, tab.id);
+      // Chrome regained focus — track the active tab of the newly focused
+      // window (which may differ from currentActiveTabId when switching
+      // between windows). Pause the previously active tab first.
+      try {
+        const [activeTab] = await chrome.tabs.query({ active: true, windowId });
+        if (activeTab && activeTab.id && activeTab.url) {
+          if (currentActiveTabId !== null && currentActiveTabId !== activeTab.id) {
+            pauseTimerForTab(currentActiveTabId);
           }
-        } catch {
-          currentActiveTabId = null;
+          currentActiveTabId = activeTab.id;
+          const hostname = extractHostname(activeTab.url);
+          handleHostname(hostname, activeTab.id);
         }
+      } catch (err) {
+        console.log('Error updating active tab on focus regain:', err);
       }
     }
   } catch (error) {

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -86,6 +86,10 @@ const DAILY_RESET_ALARM = 'dailyResetAlarm';
 const MS_IN_MINUTE = 60000;
 
 let currentActiveTabId: number | null = null;
+const removedTabIds = new Set<number>();
+
+let isRestored: boolean = false;
+let restorePromise: Promise<void> | null = null;
 
 let isInitialized: boolean = false;
 let initializationPromise: Promise<void> | null = null;
@@ -214,73 +218,94 @@ function pauseTimerForTab(tabID: string | number): void {
 }
 
 async function restoreTimers(): Promise<void> {
-  await initializeFromStorage();
+  if (isRestored) return;
+  if (restorePromise) return restorePromise;
 
-  // Determine the currently active tab so we only resume timers that
-  // should actually be running. Stored segments for non-active tabs are
-  // stale — the tab was likely not being viewed when the service worker
-  // was killed. Dropping them without folding elapsed avoids the rogue
-  // full-budget over-count that previously reset users' daily time.
-  let activeTabId: number | null = null;
-  try {
-    const [activeTab] = await chrome.tabs.query({
-      active: true,
-      lastFocusedWindow: true,
-    });
-    if (activeTab && activeTab.id) {
-      activeTabId = activeTab.id;
+  restorePromise = (async () => {
+    await initializeFromStorage();
+
+    // Determine the currently active tab so we only resume timers that
+    // should actually be running. Stored segments for non-active tabs are
+    // stale — the tab was likely not being viewed when the service worker
+    // was killed. Dropping them without folding elapsed avoids the rogue
+    // full-budget over-count that previously reset users' daily time.
+    let activeTabId: number | null = null;
+    try {
+      const [activeTab] = await chrome.tabs.query({
+        active: true,
+        lastFocusedWindow: true,
+      });
+      if (activeTab && activeTab.id) {
+        activeTabId = activeTab.id;
+      }
+    } catch (error) {
+      console.log('Could not query active tab during restore:', error);
     }
-  } catch (error) {
-    console.log('Could not query active tab during restore:', error);
-  }
-  currentActiveTabId = activeTabId;
+    currentActiveTabId = activeTabId;
 
-  for (const tabID in timerStartTimes) {
-    const timerData = timerStartTimes[tabID];
-    const hostname = timerData.hostname;
-    const startTime = timerData.startTime;
-    const timeLimit = timeLimits[hostname];
+    for (const tabID in timerStartTimes) {
+      const numericTabId = Number(tabID);
+      const timerData = timerStartTimes[tabID];
+      const hostname = timerData.hostname;
+      const startTime = timerData.startTime;
+      const timeLimit = timeLimits[hostname];
+      lastHandle[tabID] = hostname;
 
-    if (timeLimit === undefined) {
-      delete timerStartTimes[tabID];
-      clearTimeout(timers[tabID]);
-      delete timers[tabID];
-      continue;
-    }
+      if (removedTabIds.has(numericTabId)) {
+        pauseTimerForTab(tabID);
+        delete lastHandle[tabID];
+        continue;
+      }
 
-    // Only resume for the currently active tab; drop all others.
-    if (Number(tabID) !== activeTabId) {
-      delete timerStartTimes[tabID];
-      clearTimeout(timers[tabID]);
-      delete timers[tabID];
-      continue;
-    }
+      if (timeLimit === undefined) {
+        delete timerStartTimes[tabID];
+        clearTimeout(timers[tabID]);
+        delete timers[tabID];
+        continue;
+      }
 
-    if (settings.dailyTimeLimit) {
-      // Fold the elapsed segment for the active tab (it was being viewed).
-      const elapsed = Date.now() - startTime;
-      dailyTimeSpent[hostname] = (dailyTimeSpent[hostname] || 0) + elapsed;
-      delete timerStartTimes[tabID];
+      // Only resume for the currently active tab; drop all others.
+      if (numericTabId !== activeTabId) {
+        delete timerStartTimes[tabID];
+        clearTimeout(timers[tabID]);
+        delete timers[tabID];
+        continue;
+      }
 
-      const remainingMs = timeLimit * MS_IN_MINUTE - dailyTimeSpent[hostname];
-      if (remainingMs > 0) {
-        setTimerForTab(tabID, hostname, remainingMs / MS_IN_MINUTE);
-        console.log(
-          `Restored daily timer for ${hostname} on tabId: ${tabID}, ${(remainingMs / MS_IN_MINUTE).toFixed(2)} minutes remaining`
-        );
+      if (settings.dailyTimeLimit) {
+        // Fold the elapsed segment for the active tab (it was being viewed).
+        const elapsed = Date.now() - startTime;
+        dailyTimeSpent[hostname] = (dailyTimeSpent[hostname] || 0) + elapsed;
+        delete timerStartTimes[tabID];
+
+        const remainingMs = timeLimit * MS_IN_MINUTE - dailyTimeSpent[hostname];
+        if (remainingMs > 0) {
+          setTimerForTab(tabID, hostname, remainingMs / MS_IN_MINUTE);
+          console.log(
+            `Restored daily timer for ${hostname} on tabId: ${tabID}, ${(remainingMs / MS_IN_MINUTE).toFixed(2)} minutes remaining`
+          );
+        } else {
+          redirectTabToTimeExceeded(tabID);
+        }
       } else {
-        redirectTabToTimeExceeded(tabID);
-      }
-    } else {
-      const result = resumeOrExpireTimer(tabID, hostname, timeLimit, startTime);
-      if (result.resumed) {
-        console.log(
-          `Restored timer for ${hostname} on tabId: ${tabID}, ${result.remaining.toFixed(2)} minutes remaining`
-        );
+        const result = resumeOrExpireTimer(tabID, hostname, timeLimit, startTime);
+        if (result.resumed) {
+          console.log(
+            `Restored timer for ${hostname} on tabId: ${tabID}, ${result.remaining.toFixed(2)} minutes remaining`
+          );
+        }
       }
     }
+    updateStorage();
+    isRestored = true;
+  })();
+
+  try {
+    await restorePromise;
+  } catch (error) {
+    restorePromise = null;
+    throw error;
   }
-  updateStorage();
 }
 
 function handleHostname(hostname: string, tabID: number): void {
@@ -304,8 +329,8 @@ function handleHostname(hostname: string, tabID: number): void {
 
   if (timeLimits[hostname]) {
     if (settings.dailyTimeLimit) {
-      // All-day mode: only start timer when no timer is already running for this tab
-      if (!timers[tabID]) {
+      // All-day mode: only start timer when this tab is not already tracking this hostname.
+      if (!timerStartTimes[tabID] || timerStartTimes[tabID].hostname !== hostname) {
         const spentMs = dailyTimeSpent[hostname] || 0;
         const remainingMs = timeLimits[hostname] * MS_IN_MINUTE - spentMs;
         if (remainingMs <= 0) {
@@ -444,7 +469,7 @@ chrome.tabs.onUpdated.addListener(
     try {
       if (!changeInfo.url) return;
 
-      await initializeFromStorage();
+      await restoreTimers();
 
       const hostname = extractHostname(changeInfo.url);
       console.log(`Tab with id: ${tabId} was updated. New url: ${changeInfo.url}`);
@@ -465,7 +490,7 @@ chrome.tabs.onUpdated.addListener(
 
 chrome.tabs.onActivated.addListener(async (activeInfo: chrome.tabs.TabActiveInfo) => {
   try {
-    await initializeFromStorage();
+    await restoreTimers();
 
     // Daily mode: pause the timer on the tab we're switching away from
     if (
@@ -493,17 +518,26 @@ chrome.tabs.onActivated.addListener(async (activeInfo: chrome.tabs.TabActiveInfo
 });
 
 chrome.tabs.onRemoved.addListener((tabId: number) => {
-  // Clean up any timer running on the closed tab.
-  // In daily mode, pauseTimerForTab folds the elapsed segment into the
-  // budget first (the user was spending time before closing). In per-visit
-  // mode it just clears the orphaned timer without redirecting a gone tab.
-  pauseTimerForTab(tabId);
-  delete lastHandle[tabId];
+  removedTabIds.add(tabId);
+  void (async () => {
+    try {
+      await initializeFromStorage();
+      pauseTimerForTab(tabId);
+      delete lastHandle[tabId];
+      if (currentActiveTabId === tabId) {
+        currentActiveTabId = null;
+      }
+    } catch (error) {
+      console.log("Can't handle in onRemoved:", error);
+    } finally {
+      removedTabIds.delete(tabId);
+    }
+  })();
 });
 
 chrome.windows.onFocusChanged.addListener(async (windowId: number) => {
   try {
-    await initializeFromStorage();
+    await restoreTimers();
 
     // Per-visit mode tracks time while the tab is open regardless of focus.
     if (!settings.dailyTimeLimit) return;
@@ -544,7 +578,7 @@ chrome.runtime.onMessage.addListener(
   ) => {
     (async () => {
       try {
-        await initializeFromStorage();
+        await restoreTimers();
         let hostnameToApply: string | null = null;
 
         switch (request.type) {
@@ -722,7 +756,6 @@ chrome.alarms.onAlarm.addListener(async (alarm: chrome.alarms.Alarm) => {
 
 async function main(): Promise<void> {
   try {
-    await initializeFromStorage();
     await restoreTimers();
     await setupDailyResetAlarm();
   } catch (error) {

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -65,6 +65,14 @@ interface LimitItem {
   visitLimit?: number;
 }
 
+interface TimeLeftItem {
+  hostname: string;
+  timeLimit: number;
+  remainingMs: number;
+  spentMs: number;
+  isActive: boolean;
+}
+
 const visitCounts: VisitCounts = {};
 const timeLimits: Limits = {};
 const visitLimits: Limits = {};
@@ -191,8 +199,40 @@ function resumeOrExpireTimer(
   }
 }
 
+function pauseTimerForTab(tabID: string | number): void {
+  if (!timerStartTimes[tabID]) return;
+  const { hostname, startTime } = timerStartTimes[tabID];
+  if (settings.dailyTimeLimit) {
+    const elapsed = Date.now() - startTime;
+    dailyTimeSpent[hostname] = (dailyTimeSpent[hostname] || 0) + elapsed;
+    console.log(`Paused timer for ${hostname} on tab ${tabID}, accumulated ${elapsed}ms`);
+  }
+  clearTimeout(timers[tabID]);
+  delete timers[tabID];
+  updateStorage();
+}
+
 async function restoreTimers(): Promise<void> {
   await initializeFromStorage();
+
+  // Determine the currently active tab so we only resume timers that
+  // should actually be running. Stored segments for non-active tabs are
+  // stale — the tab was likely not being viewed when the service worker
+  // was killed. Dropping them without folding elapsed avoids the rogue
+  // full-budget over-count that previously reset users' daily time.
+  let activeTabId: number | null = null;
+  try {
+    const [activeTab] = await chrome.tabs.query({
+      active: true,
+      lastFocusedWindow: true,
+    });
+    if (activeTab && activeTab.id) {
+      activeTabId = activeTab.id;
+    }
+  } catch (error) {
+    console.log('Could not query active tab during restore:', error);
+  }
+  currentActiveTabId = activeTabId;
 
   for (const tabID in timerStartTimes) {
     const timerData = timerStartTimes[tabID];
@@ -202,11 +242,21 @@ async function restoreTimers(): Promise<void> {
 
     if (timeLimit === undefined) {
       delete timerStartTimes[tabID];
+      clearTimeout(timers[tabID]);
+      delete timers[tabID];
+      continue;
+    }
+
+    // Only resume for the currently active tab; drop all others.
+    if (Number(tabID) !== activeTabId) {
+      delete timerStartTimes[tabID];
+      clearTimeout(timers[tabID]);
+      delete timers[tabID];
       continue;
     }
 
     if (settings.dailyTimeLimit) {
-      // Accumulate elapsed time from the interrupted session segment
+      // Fold the elapsed segment for the active tab (it was being viewed).
       const elapsed = Date.now() - startTime;
       dailyTimeSpent[hostname] = (dailyTimeSpent[hostname] || 0) + elapsed;
       delete timerStartTimes[tabID];
@@ -313,6 +363,50 @@ function getAllLimitedHostnames(): Set<string> {
   return new Set([...Object.keys(timeLimits), ...Object.keys(visitLimits)]);
 }
 
+function computeTimeLeft(): TimeLeftItem[] {
+  const items: TimeLeftItem[] = [];
+  const now = Date.now();
+
+  for (const hostname of Object.keys(timeLimits)) {
+    const timeLimit = timeLimits[hostname];
+    if (timeLimit === undefined) continue;
+
+    const budgetMs = timeLimit * MS_IN_MINUTE;
+
+    // Elapsed time on any tab currently running a timer for this hostname.
+    // The running segment is not yet folded into dailyTimeSpent, so add it live.
+    let liveElapsedMs = 0;
+    let isActive = false;
+    for (const tabID in timerStartTimes) {
+      if (timerStartTimes[tabID].hostname === hostname) {
+        isActive = true;
+        liveElapsedMs = Math.max(liveElapsedMs, now - timerStartTimes[tabID].startTime);
+      }
+    }
+
+    let spentMs: number;
+    if (settings.dailyTimeLimit) {
+      // Daily budget accumulates across visits; add the live running segment.
+      spentMs = (dailyTimeSpent[hostname] || 0) + liveElapsedMs;
+    } else {
+      // Per-visit mode: budget is per session, so only the current session counts.
+      spentMs = liveElapsedMs;
+    }
+
+    const remainingMs = Math.max(0, budgetMs - spentMs);
+
+    items.push({
+      hostname,
+      timeLimit,
+      remainingMs,
+      spentMs: Math.min(spentMs, budgetMs),
+      isActive,
+    });
+  }
+
+  return items;
+}
+
 function updateStorage(): void {
   try {
     chrome.storage.local.set(
@@ -354,19 +448,11 @@ chrome.tabs.onUpdated.addListener(
       const hostname = extractHostname(changeInfo.url);
       console.log(`Tab with id: ${tabId} was updated. New url: ${changeInfo.url}`);
 
-      if (timers[tabId] && lastHandle[tabId] && lastHandle[tabId] !== hostname) {
-        if (settings.dailyTimeLimit && timerStartTimes[tabId]) {
-          const elapsed = Date.now() - timerStartTimes[tabId].startTime;
-          dailyTimeSpent[timerStartTimes[tabId].hostname] =
-            (dailyTimeSpent[timerStartTimes[tabId].hostname] || 0) + elapsed;
-        }
-        clearTimeout(timers[tabId]);
-        delete timers[tabId];
-        delete timerStartTimes[tabId];
+      if (timerStartTimes[tabId] && lastHandle[tabId] && lastHandle[tabId] !== hostname) {
+        pauseTimerForTab(tabId);
         console.log(
           `Cleared timer on tabId: ${tabId}, hostname changed from ${lastHandle[tabId]} to ${hostname}`
         );
-        updateStorage();
       }
 
       handleHostname(hostname, tabId);
@@ -380,25 +466,13 @@ chrome.tabs.onActivated.addListener(async (activeInfo: chrome.tabs.TabActiveInfo
   try {
     await initializeFromStorage();
 
-    // All-day mode: pause the timer on the tab we're switching away from
+    // Daily mode: pause the timer on the tab we're switching away from
     if (
       settings.dailyTimeLimit &&
       currentActiveTabId !== null &&
       currentActiveTabId !== activeInfo.tabId
     ) {
-      const prevTabId = currentActiveTabId;
-      if (timerStartTimes[prevTabId]) {
-        const { hostname, startTime } = timerStartTimes[prevTabId];
-        const elapsed = Date.now() - startTime;
-        dailyTimeSpent[hostname] = (dailyTimeSpent[hostname] || 0) + elapsed;
-        clearTimeout(timers[prevTabId]);
-        delete timers[prevTabId];
-        delete timerStartTimes[prevTabId];
-        console.log(
-          `Paused daily timer for ${hostname} on tab ${prevTabId}, accumulated ${elapsed}ms`
-        );
-        updateStorage();
-      }
+      pauseTimerForTab(currentActiveTabId);
     }
 
     currentActiveTabId = activeInfo.tabId;
@@ -414,6 +488,46 @@ chrome.tabs.onActivated.addListener(async (activeInfo: chrome.tabs.TabActiveInfo
     });
   } catch (error) {
     console.log("Can't handle in onActivated:", error);
+  }
+});
+
+chrome.tabs.onRemoved.addListener((tabId: number) => {
+  // Clean up any timer running on the closed tab.
+  // In daily mode, pauseTimerForTab folds the elapsed segment into the
+  // budget first (the user was spending time before closing). In per-visit
+  // mode it just clears the orphaned timer without redirecting a gone tab.
+  pauseTimerForTab(tabId);
+  delete lastHandle[tabId];
+});
+
+chrome.windows.onFocusChanged.addListener(async (windowId: number) => {
+  try {
+    await initializeFromStorage();
+
+    // Per-visit mode tracks time while the tab is open regardless of focus.
+    if (!settings.dailyTimeLimit) return;
+
+    if (windowId === chrome.windows.WINDOW_ID_NONE) {
+      // Chrome lost focus — pause the active tab's timer.
+      if (currentActiveTabId !== null) {
+        pauseTimerForTab(currentActiveTabId);
+      }
+    } else {
+      // Chrome regained focus — resume the active tab's timer if limited.
+      if (currentActiveTabId !== null) {
+        try {
+          const tab = await chrome.tabs.get(currentActiveTabId);
+          if (tab && tab.url && tab.id) {
+            const hostname = extractHostname(tab.url);
+            handleHostname(hostname, tab.id);
+          }
+        } catch {
+          currentActiveTabId = null;
+        }
+      }
+    }
+  } catch (error) {
+    console.log("Can't handle onFocusChanged:", error);
   }
 });
 
@@ -532,6 +646,12 @@ chrome.runtime.onMessage.addListener(
             });
 
             sendResponse({ limits });
+            break;
+          }
+
+          case 'getTimeLeft': {
+            console.log('getTimeLeft called');
+            sendResponse({ timeLeft: computeTimeLeft() });
             break;
           }
         }

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -602,6 +602,9 @@ chrome.runtime.onMessage.addListener(
               timeLimits[hostname] = t;
               updateStorage();
               hostnameToApply = hostname;
+              sendResponse({ success: true });
+            } else {
+              sendResponse({ success: false });
             }
             break;
           }

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -42,6 +42,7 @@ interface StorageData {
   timerStartTimes?: TimerStartTimes;
   dailyTimeSpent?: DailyTimeSpent;
   settings?: Settings;
+  lastDailyResetDate?: string;
 }
 
 interface MessageRequest {
@@ -83,6 +84,43 @@ const dailyTimeSpent: DailyTimeSpent = {};
 const settings: Settings = { ...DEFAULT_SETTINGS };
 
 const DAILY_RESET_ALARM = 'dailyResetAlarm';
+let lastDailyResetDate: string | undefined;
+
+function getLocalDateKey(date: Date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function clearRecord<T>(record: { [key: string]: T }): void {
+  for (const member in record) delete record[member];
+}
+
+function clearDailyResetState(resetDate: string): void {
+  clearRecord(visitCounts);
+  clearRecord(dailyTimeSpent);
+  for (const tabID in timers) {
+    clearTimeout(timers[tabID]);
+    delete timers[tabID];
+  }
+  clearRecord(timerStartTimes);
+  clearRecord(lastHandle);
+  lastDailyResetDate = resetDate;
+}
+
+function syncDailyResetDate(): boolean {
+  const today = getLocalDateKey();
+  if (!lastDailyResetDate) {
+    lastDailyResetDate = today;
+    return true;
+  }
+  if (lastDailyResetDate !== today) {
+    clearDailyResetState(today);
+    return true;
+  }
+  return false;
+}
 const MS_IN_MINUTE = 60000;
 
 let currentActiveTabId: number | null = null;
@@ -100,7 +138,15 @@ async function initializeFromStorage(): Promise<void> {
 
   initializationPromise = new Promise((resolve, reject) => {
     chrome.storage.local.get(
-      ['timeLimits', 'visitLimits', 'visitCounts', 'timerStartTimes', 'dailyTimeSpent', 'settings'],
+      [
+        'timeLimits',
+        'visitLimits',
+        'visitCounts',
+        'timerStartTimes',
+        'dailyTimeSpent',
+        'settings',
+        'lastDailyResetDate',
+      ],
       (result: StorageData) => {
         if (chrome.runtime.lastError) {
           console.error('Error loading data from storage:', chrome.runtime.lastError);
@@ -118,12 +164,15 @@ async function initializeFromStorage(): Promise<void> {
             Object.assign(timerStartTimes, result.timerStartTimes);
           if (result && result.dailyTimeSpent) Object.assign(dailyTimeSpent, result.dailyTimeSpent);
           if (result && result.settings) Object.assign(settings, result.settings);
+          if (result && result.lastDailyResetDate) lastDailyResetDate = result.lastDailyResetDate;
+          const didSyncDailyResetDate = syncDailyResetDate();
           console.log('Loaded persisted data from storage:', {
             timeLimits,
             visitLimits,
             visitCounts,
             timerStartTimes,
           });
+          if (didSyncDailyResetDate) updateStorage();
           isInitialized = true;
           resolve();
         } catch (e) {
@@ -443,6 +492,7 @@ function updateStorage(): void {
         visitCounts: visitCounts,
         timerStartTimes: timerStartTimes,
         dailyTimeSpent: dailyTimeSpent,
+        lastDailyResetDate: lastDailyResetDate,
       },
       () => {
         if (chrome.runtime.lastError) {
@@ -455,6 +505,7 @@ function updateStorage(): void {
             visitCounts,
             timerStartTimes,
             dailyTimeSpent,
+            lastDailyResetDate,
           });
         }
       }
@@ -734,14 +785,7 @@ chrome.alarms.onAlarm.addListener(async (alarm: chrome.alarms.Alarm) => {
     try {
       console.log('Daily reset triggered at', new Date().toLocaleString());
 
-      for (const member in visitCounts) delete visitCounts[member];
-      for (const member in dailyTimeSpent) delete dailyTimeSpent[member];
-      for (const tabID in timers) {
-        clearTimeout(timers[tabID]);
-        delete timers[tabID];
-      }
-      for (const member in timerStartTimes) delete timerStartTimes[member];
-      for (const tabID in lastHandle) delete lastHandle[tabID];
+      clearDailyResetState(getLocalDateKey());
 
       updateStorage();
       console.log('Visit counts, timers, and timer data reset for new day');

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -110,6 +110,20 @@ function formatDuration(ms: number): string {
   return `${seconds}s`;
 }
 
+function escapeHtml(str: string): string {
+  return str.replace(/[&<>"'/]/g, (m) => {
+    const map: Record<string, string> = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+      '/': '&#x2F;',
+    };
+    return map[m];
+  });
+}
+
 function renderTimeLeft(items: TimeLeftItem[]): void {
   const content = document.getElementById('timeLeftContent');
   if (!content) return;
@@ -138,7 +152,7 @@ function renderTimeLeft(items: TimeLeftItem[]): void {
     const exhausted = item.remainingMs <= 0;
 
     html += `
-      <div class="time-left-card" data-hostname="${item.hostname}">
+      <div class="time-left-card" data-hostname="${escapeHtml(item.hostname)}">
         <div class="time-left-card-header">
           <div class="time-left-icon">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -146,8 +160,7 @@ function renderTimeLeft(items: TimeLeftItem[]): void {
               <path d="M12 6v6l4 2"/>
             </svg>
           </div>
-          <div class="time-left-hostname">${item.hostname}</div>
-          <div class="time-left-status ${item.isActive ? 'active' : ''}">${item.isActive ? '● Active' : ''}</div>
+          <div class="time-left-hostname">${escapeHtml(item.hostname)}</div>
         </div>
         <div class="time-left-row">
           <div class="time-left-label">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -345,6 +345,7 @@ interface LimitsManager {
   setLimits: (limits: LimitItem[]) => void;
   getLimits: () => LimitItem[];
   removeLimitByHostname: (hostname: string) => void;
+  updateTimeLimit: (hostname: string, timeLimit: number) => void;
 }
 
 const createLimitsManager = (): LimitsManager => {
@@ -357,6 +358,11 @@ const createLimitsManager = (): LimitsManager => {
     getLimits: () => currentLimits,
     removeLimitByHostname: (hostname: string) => {
       currentLimits = currentLimits.filter((l) => l.hostname !== hostname);
+    },
+    updateTimeLimit: (hostname: string, timeLimit: number) => {
+      currentLimits = currentLimits.map((limit) =>
+        limit.hostname === hostname ? { ...limit, timeLimit } : limit
+      );
     },
   };
 };
@@ -386,35 +392,37 @@ function renderLimits(limits: LimitItem[], filterText: string = ''): void {
 
   let limitsHTML = '';
   filtered.forEach((limit) => {
+    const escapedHostname = escapeHtml(limit.hostname);
+    const escapedTimeLimit = limit.timeLimit ? escapeHtml(String(limit.timeLimit)) : '';
+
     limitsHTML += `
-      <div class="limit-card" data-hostname="${limit.hostname}">
+      <div class="limit-card" data-hostname="${escapedHostname}">
         <div class="limit-header">
           <div class="limit-icon">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"/>
             </svg>
           </div>
-          <div class="limit-hostname">${limit.hostname}</div>
-          <button class="delete-limit-btn icon-btn" data-hostname="${limit.hostname}" aria-label="Delete limit">
+          <div class="limit-hostname">${escapedHostname}</div>
+          <button class="delete-limit-btn icon-btn" data-hostname="${escapedHostname}" aria-label="Delete limit">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/>
             </svg>
           </button>
         </div>
         <div class="limit-details">
-          ${
-            limit.timeLimit
-              ? `
-          <div class="limit-detail">
+          <div class="limit-detail limit-edit-row">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <circle cx="12" cy="12" r="10"/>
               <path d="M12 6v6l4 2"/>
             </svg>
-            <span>${limit.timeLimit} minutes per visit</span>
+            <label class="limit-edit-label">
+              <span class="sr-only">Time limit for ${escapedHostname}</span>
+              <input class="limit-time-input" type="number" min="1" value="${escapedTimeLimit}" placeholder="No limit" aria-label="Time limit for ${escapedHostname} in minutes" />
+            </label>
+            <span class="limit-edit-unit">minutes per visit</span>
+            <button class="save-limit-btn" type="button" data-hostname="${escapedHostname}">Save</button>
           </div>
-          `
-              : ''
-          }
           ${
             limit.visitLimit
               ? `
@@ -434,6 +442,43 @@ function renderLimits(limits: LimitItem[], filterText: string = ''): void {
   });
 
   limitsContent.innerHTML = limitsHTML;
+
+  document.querySelectorAll<HTMLButtonElement>('.save-limit-btn').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const hostname = btn.getAttribute('data-hostname');
+      const limitCard = btn.closest('.limit-card');
+      const timeLimitInput = limitCard?.querySelector<HTMLInputElement>('.limit-time-input');
+      if (!hostname || !timeLimitInput) return;
+
+      const timeLimit = Number(timeLimitInput.value);
+      if (!Number.isFinite(timeLimit) || timeLimit <= 0) {
+        showMessage('Enter a time limit greater than 0 minutes', 5000, true);
+        return;
+      }
+
+      btn.disabled = true;
+      try {
+        const response = (await chrome.runtime.sendMessage({
+          type: 'setTimeLimit',
+          hostname,
+          timeLimit,
+        })) as DeLimitResponse;
+        if (!response?.success) {
+          btn.disabled = false;
+          showMessage(`Failed to update time limit for ${hostname}`, 5000, true);
+          return;
+        }
+        limitsManager.updateTimeLimit(hostname, timeLimit);
+        renderLimits(limitsManager.getLimits(), searchInput?.value ?? '');
+        showMessage(`Time limit updated for ${hostname}`);
+
+      } catch (error) {
+        console.error('Error updating time limit:', error);
+        btn.disabled = false;
+        showMessage(`Failed to update time limit for ${hostname}`, 5000, true);
+      }
+    });
+  });
 
   document.querySelectorAll<HTMLButtonElement>('.delete-limit-btn').forEach((btn) => {
     btn.addEventListener('click', async (e: Event) => {

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -6,6 +6,8 @@ import type {
   LimitsResponse,
   DeLimitResponse,
   SettingsResponse,
+  TimeLeftItem,
+  TimeLeftResponse,
 } from '../shared/types.js';
 
 function initTabs(): void {
@@ -27,7 +29,9 @@ function initTabs(): void {
         targetElement.classList.add('active');
       }
 
-      if (targetTab === 'stats') {
+      if (targetTab === 'time-left') {
+        loadTimeLeft();
+      } else if (targetTab === 'stats') {
         loadStats();
       } else if (targetTab === 'all-limits') {
         loadAllLimits();
@@ -89,6 +93,107 @@ if (form) {
     timeLimitInput.value = '';
     visitLimitInput.value = '';
   });
+}
+
+function formatDuration(ms: number): string {
+  const totalMinutes = Math.floor(ms / 60000);
+  const seconds = Math.floor((ms % 60000) / 1000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+function renderTimeLeft(items: TimeLeftItem[]): void {
+  const content = document.getElementById('timeLeftContent');
+  if (!content) return;
+
+  if (items.length === 0) {
+    content.innerHTML = `
+      <div class="empty-state">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <circle cx="12" cy="12" r="10"/>
+          <path d="M12 6v6l4 2"/>
+        </svg>
+        <p>No time budgets set yet</p>
+      </div>
+    `;
+    return;
+  }
+
+  const sorted = [...items].sort((a, b) => a.remainingMs - b.remainingMs);
+
+  let html = '';
+  sorted.forEach((item) => {
+    const budgetMs = item.timeLimit * 60000;
+    const spentPercent = budgetMs > 0 ? Math.min(100, (item.spentMs / budgetMs) * 100) : 0;
+    const remainingPercent = 100 - spentPercent;
+    const barColor = remainingPercent <= 0 ? 'danger' : remainingPercent <= 34 ? 'warning' : 'success';
+    const exhausted = item.remainingMs <= 0;
+
+    html += `
+      <div class="time-left-card" data-hostname="${item.hostname}">
+        <div class="time-left-card-header">
+          <div class="time-left-icon">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="10"/>
+              <path d="M12 6v6l4 2"/>
+            </svg>
+          </div>
+          <div class="time-left-hostname">${item.hostname}</div>
+          <div class="time-left-status ${item.isActive ? 'active' : ''}">${item.isActive ? '● Active' : ''}</div>
+        </div>
+        <div class="time-left-row">
+          <div class="time-left-label">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="10"/>
+              <path d="M12 6v6l4 2"/>
+            </svg>
+            <span>Time left</span>
+          </div>
+          <div class="time-left-value ${exhausted ? 'exhausted' : ''}">${exhausted ? 'Exhausted' : formatDuration(item.remainingMs)}</div>
+        </div>
+        <div class="progress-bar">
+          <div class="progress-fill ${barColor}" style="width: ${remainingPercent}%"></div>
+        </div>
+        <div class="time-left-progress-label">
+          <span>${formatDuration(item.spentMs)} used</span>
+          <span>${item.timeLimit} min budget</span>
+        </div>
+      </div>
+    `;
+  });
+
+  content.innerHTML = html;
+}
+
+async function loadTimeLeft(): Promise<void> {
+  const content = document.getElementById('timeLeftContent');
+  if (!content) return;
+
+  content.innerHTML = '<div class="loading">Loading time left...</div>';
+
+  try {
+    const response = (await chrome.runtime.sendMessage({
+      type: 'getTimeLeft',
+    })) as TimeLeftResponse;
+
+    if (!response || !response.timeLeft) {
+      renderTimeLeft([]);
+      return;
+    }
+
+    renderTimeLeft(response.timeLeft);
+  } catch (error) {
+    console.error('Error loading time left:', error);
+    content.innerHTML = '<div class="error-state">Failed to load time left</div>';
+  }
 }
 
 async function loadStats(): Promise<void> {
@@ -358,6 +463,17 @@ if (refreshStatsBtn) {
     const btn = refreshStatsBtn;
     btn.classList.add('spinning');
     loadStats().finally(() => {
+      setTimeout(() => btn.classList.remove('spinning'), 500);
+    });
+  });
+}
+
+const refreshTimeLeftBtn = document.getElementById('refreshTimeLeft');
+if (refreshTimeLeftBtn) {
+  refreshTimeLeftBtn.addEventListener('click', () => {
+    const btn = refreshTimeLeftBtn;
+    btn.classList.add('spinning');
+    loadTimeLeft().finally(() => {
       setTimeout(() => btn.classList.remove('spinning'), 500);
     });
   });
@@ -641,6 +757,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initExportStats();
   initLogoEasterEgg();
   startTipRotation();
+  loadTimeLeft();
 
   const settingsBtn = document.getElementById('settingsBtn');
   if (settingsBtn) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -11,6 +11,18 @@ export interface LimitItem {
   visitLimit?: number;
 }
 
+export interface TimeLeftItem {
+  hostname: string;
+  timeLimit: number;
+  remainingMs: number;
+  spentMs: number;
+  isActive: boolean;
+}
+
+export interface TimeLeftResponse {
+  timeLeft: TimeLeftItem[];
+}
+
 export interface StatsResponse {
   stats: StatItem[];
 }
@@ -34,6 +46,7 @@ export interface SettingsResponse {
 export type MessageResponse =
   | StatsResponse
   | LimitsResponse
+  | TimeLeftResponse
   | DeLimitResponse
   | SettingsResponse
   | void;


### PR DESCRIPTION
## Summary

This PR adds a **Time Left** tab — a new default popup tab that shows remaining daily time budget per domain — and fixes three timer lifecycle bugs that made the daily time budget unreliable in practice.

Closes the core user pain point: *"with sites that have a daily time limit, it's impossible to see how much time I have left until the time budget runs out."*

---

## ✨ New Feature: Time Left Tab

A new tab that opens by default when the popup is clicked, giving at-a-glance visibility into how much time remains on every budgeted domain.

**What it shows per domain:**
- Remaining time (formatted as `Xh Ym Zs`)
- Time used vs. total budget
- Color-coded progress bar:
  - 🟢 green — under 66% used
  - 🟡 amber — 66–100% used
  - 🔴 red — exhausted
- **● Active** badge for the site currently burning time (live elapsed segment folded in)
- Sorted by least time remaining first

**Empty state:** "No time budgets set yet" with a prompt to add limits.

**How it works:**
- `getSettings` + `getTimeLeft` message types added to `src/shared/types.ts`
- `computeTimeLeft()` in background folds the live running segment (`Date.now() - timerStartTimes[tab].startTime`) on top of stored `dailyTimeSpent`, so the displayed remaining time is accurate even mid-session
- In daily-budget mode: shows time left in the daily allowance
- In per-visit mode: shows time left in the current session
- `loadTimeLeft()` / `renderTimeLeft()` in popup, loaded on popup open, tab click, and via a ↻ refresh button

---

## 🐛 Bug Fixes: Timer Lifecycle

The timer was a wall-clock `setTimeout` that only paused on tab-switch and URL change. This caused three failure modes:

### 1. Timer decrements without an active tab

**Symptom:** Switching to another app (Slack, editor) left the timer ticking — daily budget drained while Chrome had no focus.

**Root cause:** No `chrome.windows.onFocusChanged` listener. Tab activation events only fire within Chrome.

**Fix:** Added `windows.onFocusChanged` listener. When `windowId === chrome.windows.WINDOW_ID_NONE` (Chrome lost focus), pause the active tab's timer. When focus returns, resume via `handleHostname`. Only applies in daily-budget mode (per-visit mode tracks time while the tab is open regardless of focus, per existing spec).

### 2. Closing the tab doesn't stop the timer

**Symptom:** Closing a tab mid-session orphaned its `setTimeout`. In daily mode, the orphaned timer later fired and silently set `dailyTimeSpent = full budget` — exhausting the entire day's allowance in one shot.

**Root cause:** No `chrome.tabs.onRemoved` handler.

**Fix:** Added `onRemoved` listener that calls `pauseTimerForTab` (folds elapsed in daily mode, clears in both modes) and cleans up `lastHandle[tabId]`.

### 3. Rogue daily budget reset a few minutes in

**Symptom:** After a few minutes of use, tabbing out and back showed the timer had reset / budget was corrupted.

**Root cause (two parts):**
- `currentActiveTabId` was in-memory only. MV3 kills the service worker after ~30s idle; on restart it was `null`, so `onActivated`'s pause block (`currentActiveTabId !== null`) silently no-oped — switching tabs stopped pausing.
- `restoreTimers()` blindly folded `Date.now() - storedStartTime` for ALL stored `timerStartTimes`. If the SW was dead for N minutes, it counted N minutes against the budget.

**Fix:**
- `restoreTimers()` now queries the active tab via `chrome.tabs.query({ active: true, lastFocusedWindow: true })` and restores `currentActiveTabId` on startup.
- Only resumes the timer for the **currently active tab**; all other stale segments are dropped without folding (conservative — avoids over-counting).

### 4. Refactor: `pauseTimerForTab` helper

The same fold-elapsed-then-clear logic was duplicated in `onActivated`, `onUpdated` (URL change), and the new `onRemoved`. Extracted into a single `pauseTimerForTab(tabID)` helper to keep the accounting consistent.

---

## 📁 Files Changed

| File | Changes |
|------|---------|
| `src/shared/types.ts` | `TimeLeftItem`, `TimeLeftResponse` types; added to `MessageResponse` union |
| `src/background/background.ts` | `computeTimeLeft()`, `getTimeLeft` handler, `pauseTimerForTab` helper, `onRemoved` + `onFocusChanged` listeners, `restoreTimers` rewrite, `onActivated`/`onUpdated` refactor |
| `src/popup/popup.ts` | `loadTimeLeft()`, `renderTimeLeft()`, `formatDuration()`, refresh button wiring, load on DOMContentLoaded |
| `public/popup.html` | Time Left tab button + content section, made default active tab |
| `public/popup.css` | Time Left card styling, progress bar, color states, active badge, empty state |

---

## 🧪 Manual Testing

**Setup:** Enable **Daily Time Budget Mode** in Settings, add a site with a 2-minute time limit.

1. **Time Left display:** Open popup → Time Left tab shows the site with ~2m 0s remaining, 0s used, green bar.
2. **Active tracking:** Browse the site ~30s, reopen popup → remaining drops, used climbs, **● Active** badge shows.
3. **Focus loss pause:** Browse ~20s, Alt-Tab to another app for 30s, come back → remaining should only drop ~20s, not 50s.
4. **Tab close cleanup:** Close the tab mid-session, reopen popup → remaining reflects only pre-close time. Revisit the site → NOT redirected to time-exceeded.
5. **No rogue reset:** Browse 2 min, switch to another tab for a few minutes, come back → timer picks up where it left off.
6. **Color transitions:** Let it run past 66% → amber; past budget → red "Exhausted".
7. **Empty state:** Delete all time limits → "No time budgets set yet".

---

## 📝 Notes

- No manifest permission changes needed. `chrome.tabs.onRemoved` and `chrome.windows.onFocusChanged` require only `"tabs"`, which is already declared.
- TypeScript compiles clean (`tsc --noEmit` passes).
- Existing tests not modified (no behavioral test changes — happy to add tests for the new message handler and timer lifecycle if desired).